### PR TITLE
Write a function for fuzzy matching

### DIFF
--- a/load_paws_data.ipynb
+++ b/load_paws_data.ipynb
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 25,
    "metadata": {
     "collapsed": true
    },
@@ -1288,8 +1288,11 @@
     "def single_fuzzy_score(record1, record2):\n",
     "    # Calculate a fuzzy matching score between two strings.\n",
     "    # Uses a modified Levenshtein distance from the fuzzywuzzy package.\n",
-    "    # Update this function if a new fuzzy matching algorithm is selected\n",
-    "    return fuzz.ratio(record1, record2)\n",
+    "    # Update this function if a new fuzzy matching algorithm is selected.\n",
+    "    # Similar to the example of \"New York Yankees\" vs. \"Yankees\" in the documentation, we \n",
+    "    # should use fuzz.partial_ratio instead of fuzz.ratio to more gracefully handle nicknames.\n",
+    "    # https://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/\n",
+    "    return fuzz.partial_ratio(record1, record2)\n",
     "\n",
     "def df_fuzzy_score(df, column1_name, column2_name):\n",
     "    # Calculates a new column of fuzzy scores from two columns of strings.\n",
@@ -1299,8 +1302,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Calculate fuzzy matching with fuzzywuzzy or another package\n",
@@ -1337,7 +1342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1398,7 +1403,7 @@
        "      <td>NaN</td>\n",
        "      <td>nan</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>33</td>\n",
+       "      <td>67</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -1411,7 +1416,7 @@
        "      <td>NaN</td>\n",
        "      <td>nan</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>13</td>\n",
+       "      <td>33</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -1424,7 +1429,7 @@
        "      <td>NaN</td>\n",
        "      <td>nan</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>35</td>\n",
+       "      <td>67</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1460,13 +1465,13 @@
        "\n",
        "  volgistics_name  volgistics_id  fuzzy_score  \n",
        "0    ipsum, lorem            0.0          100  \n",
-       "1             nan            NaN           33  \n",
-       "2             nan            NaN           13  \n",
-       "3             nan            NaN           35  \n",
+       "1             nan            NaN           67  \n",
+       "2             nan            NaN           33  \n",
+       "3             nan            NaN           67  \n",
        "4             nan            NaN            0  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1477,7 +1482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 28,
    "metadata": {
     "collapsed": true
    },
@@ -1489,7 +1494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1570,7 +1575,7 @@
        "5           10.0          100  "
       ]
      },
-     "execution_count": 23,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/load_paws_data.ipynb
+++ b/load_paws_data.ipynb
@@ -1045,7 +1045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
@@ -1061,7 +1061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1116,7 +1116,7 @@
        "1       Bean, Jim  jimb3@gmail.com             10     bean, jim"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1132,7 +1132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1255,7 +1255,7 @@
        "4             nan            NaN  "
       ]
      },
-     "execution_count": 59,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1278,20 +1278,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from fuzzywuzzy import fuzz\n",
+    "def single_fuzzy_score(record1, record2):\n",
+    "    # Calculate a fuzzy matching score between two strings.\n",
+    "    # Uses a modified Levenshtein distance from the fuzzywuzzy package.\n",
+    "    # Update this function if a new fuzzy matching algorithm is selected\n",
+    "    return fuzz.ratio(record1, record2)\n",
+    "\n",
+    "def df_fuzzy_score(df, column1_name, column2_name):\n",
+    "    # Calculates a new column of fuzzy scores from two columns of strings.\n",
+    "    # Slow in part due to a nonvectorized loop over rows\n",
+    "    return df.apply(lambda row: single_fuzzy_score(row[column1_name], row[column2_name]), axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate fuzzy matching with fuzzywuzzy or another package\n",
-    "master_with_volgistics['fuzzy_score'] = master_with_volgistics.apply(\n",
-    "    lambda row: fuzz.ratio(row['name'], row['volgistics_name']),\n",
-    "    axis=1  # rowwise\n",
-    ")\n",
+    "master_with_volgistics['fuzzy_score'] = df_fuzzy_score(master_with_volgistics, 'name', 'volgistics_name')\n",
     "master_with_volgistics.head()\n",
     "\n",
     "# Forward the results for review, only keeping results with suitable emails/names\n",
     "fuzzy_name_cutoff = 70  # FIXME: arbitrarily picked a value for now.  Will need to tune this variable\n",
-    "#fuzzy_name_cutoff = 170  # impossible: uncomment to test the csv outputs here\n",
+    "\n",
+    "# TODO experiments, before the fuzzy matching can be productionalized:\n",
+    "# * Does the fuzzywuzzy algorithm work on our dataset? (or should we find/create a new method?)\n",
+    "# * What is the optimal cutoff to balance false positives/false negatives of name matches?\n",
+    "# * How does the performance compare if we apply the fuzzy match on full name vs. first/last names separately?\n",
+    "\n",
+    "#fuzzy_name_cutoff = 170  # impossible case: Uncommenting this line of code will ensure different csv's are written below:\n",
+    "\n",
     "(\n",
     "    master_with_volgistics\n",
     "    [(~master_with_volgistics['volgistics_id'].isnull()) & (master_with_volgistics['fuzzy_score'] < fuzzy_name_cutoff)]\n",
@@ -1312,7 +1337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1441,7 +1466,7 @@
        "4             nan            NaN            0  "
       ]
      },
-     "execution_count": 61,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1452,8 +1477,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
-   "metadata": {},
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Save the volgistics ID's back to the master data\n",
@@ -1462,7 +1489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1543,7 +1570,7 @@
        "5           10.0          100  "
       ]
      },
-     "execution_count": 64,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1569,11 +1596,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "Joins above not yet finished",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-24-f6a752eee509>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Joins above not yet finished\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[1;31m# load_to_sqlite(master_df, master_table, conn)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mValueError\u001b[0m: Joins above not yet finished"
+     ]
+    }
+   ],
    "source": [
     "raise ValueError(\"Joins above not yet finished\")\n",
     "# load_to_sqlite(master_df, master_table, conn)"
@@ -1661,7 +1698,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Implements a proof-of-concept for #9 as a function based on the fuzzywuzzy library.  Finishing the second half of #9 will require some tuning of the fuzzy matching threshold on real names.

This updated code uses the `partial_ratio` function to avoid penalizing nicknames that are substrings.  For example, "Ben" should be a perfect match for "Benjamin."  A standard edit distance calculation would calculate the difference as the deletion of five characters, so allowing partial substring matching is a good alternative.

Aside: if we decide to rewrite our ETL as in-database operations, it looks like many fuzzy string algorithms are included as modules for [PostgreSQL](https://www.postgresql.org/docs/9.1/fuzzystrmatch.html#AEN139557) and [sqlite3](https://www.sqlite.org/spellfix1.html#the_editdist3_function).  In addition to the Levenstein distance, there are other techniques such as Soundex and double metaphone.