### PR TITLE
[WIP] Test matching rules on PAWS data

### DIFF
--- a/notebooks/test_fuzzy_match_on_real_data.ipynb
+++ b/notebooks/test_fuzzy_match_on_real_data.ipynb
@@ -1,0 +1,795 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fuzzy matching exploration\n",
+    "\n",
+    "Run EDA to test the fuzzy matching code from [PR #35](https://github.com/CodeForPhilly/paws-data-pipeline/pull/35) to determine if the original email + name fuzzy matching business logic is sufficient for joining the tables, or if we should continue to explore alternative approaches (e.g. [#36](https://github.com/CodeForPhilly/paws-data-pipeline/issues/36)).\n",
+    "\n",
+    "**Usage guide:** This notebook contains some analysis code that was run on an extract from PAWS.  These files are loaded from a local Originals/ directory and are not published to GitHub (see block 6 below).  **WARNING:** this notebook is intended to be read-only to inform future work in the Python data pipeline.  If you modify the .ipynb file and rerun on real data, be sure to triple-check any changes before commiting any data into the repo.\n",
+    "\n",
+    "**Future work:** Should brainstorm the matching criteria in more detail, possibly coming up with a flowchart or Sankey diagram showing how many records are each step. (e.g., there are only ~100 records in each dataset where the names do not match but the emails do.  Since the number is small, that indicates that fuzzy matching may not be necessary at all.)  Also productionalizing this workflow from an exploratory notebook into the full Python scripts.\n",
+    "\n",
+    "**Current conclusions and understanding from this analysis:**\n",
+    "\n",
+    "1. Using the email address by itself was surprisingly effective to match users between the datasets.  Running a case insensitive search (or normalizing all of the emails to lowercase) improves the matching effectiveness.\n",
+    "2. There are many records in salesforce that share an email address, including name changes, shared household emails, and duplicate entries from ticketed events.\n",
+    "3. The volgistics dataset was quite clean, with only three emails shared in the whole dataset.\n",
+    "4. Petpoint was a bit messier: about 100 records without an email address, and surprisingly ~1/3 of the given emails were not in salesforce.  More work should be done to understand this subset of emails and how to proceed.\n",
+    "5. In the petpoint and volgistics matches against salesforce, there were 100 cases each where the emails matched but the names did not.  Given the nature of these mismatches (typically name changes, middle names, nicknames, etc.), it appears that improving the matching rules (e.g. preprocessing) and/or correcting the source data would be more effective for our use case than establishing a fuzzy match threshold.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import libraries and define generic utilities\n",
+    "\n",
+    "Copying useful methods from load_paws_data.ipynb, minus the export to a sqlite database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import sqlite3\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import re\n",
+    "from fuzzywuzzy import fuzz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pd.options.display.max_columns = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def load_df(csv_name, drop_first_col=False):\n",
+    "    # adapted from load_to_sqlite\n",
+    "    df = pd.read_csv(csv_name, encoding='cp1252')\n",
+    "    \n",
+    "    # drop the first column - so far all csvs have had a first column that's an index and doesn't have a name\n",
+    "    if drop_first_col:\n",
+    "        df = df.drop(df.columns[0], axis=1)\n",
+    "    \n",
+    "    # strip whitespace and periods from headers, convert to lowercase\n",
+    "    df.columns = df.columns.str.lower().str.strip()\n",
+    "    df.columns = df.columns.str.replace(' ', '_')\n",
+    "    df.columns = df.columns.map(lambda x: re.sub(r'\\.+', '_', x))\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def clean_entry(entry):\n",
+    "    \"\"\"\n",
+    "    Function to clean up all values returned from the SQL statement, so this \n",
+    "    should be performed on every entry in the dataframe with an applymap\n",
+    "    \n",
+    "    1 Change 'None' or 'NaN' value to an empty string\n",
+    "    2 Cast value as string\n",
+    "    3 Lowercase value\n",
+    "    3 Strip leading and trailing white space\n",
+    "    4 Remove punctuation by only keeping letters, numbers and white space\n",
+    "    5 Replace internal multiple consecutive white spaces with a single white space\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # convert None and NaN to an empty string\n",
+    "    if entry ==  None or entry == np.nan:\n",
+    "        entry = ''\n",
+    "    \n",
+    "    # convert to string, lowercase, and strip leading and trailing whitespace\n",
+    "    entry = str(entry).lower().strip()\n",
+    "    \n",
+    "#    # remove all non alphanumeric characters except white space\n",
+    "#    alphanumeric_and_space = ' 1234567890abcdefghijklmnopqrstuvwxyz'\n",
+    "#    entry = ''.join([c for c in entry if c in alphanumeric_and_space])\n",
+    "    \n",
+    "    # cut down (internal) consecutive whitespaces to one white space\n",
+    "    entry = re.sub(r'\\s+', ' ', entry)\n",
+    "    \n",
+    "    return entry\n",
+    "\n",
+    "# usage example:\n",
+    "# df = df.applymap(clean_entry)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from fuzzywuzzy import fuzz\n",
+    "def single_fuzzy_score(record1, record2):\n",
+    "    # Calculate a fuzzy matching score between two strings.\n",
+    "    # Uses a modified Levenshtein distance from the fuzzywuzzy package.\n",
+    "    # Update this function if a new fuzzy matching algorithm is selected.\n",
+    "    # Similar to the example of \"New York Yankees\" vs. \"Yankees\" in the documentation, we \n",
+    "    # should use fuzz.partial_ratio instead of fuzz.ratio to more gracefully handle nicknames.\n",
+    "    # https://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/\n",
+    "    return fuzz.partial_ratio(record1, record2)\n",
+    "\n",
+    "def df_fuzzy_score(df, column1_name, column2_name):\n",
+    "    # Calculates a new column of fuzzy scores from two columns of strings.\n",
+    "    # Slow in part due to a nonvectorized loop over rows\n",
+    "    return df.apply(lambda row: single_fuzzy_score(row[column1_name], row[column2_name]), axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "orig_petpoint = load_df('./Original/PetPoint - AnimalIntakeWithResultsExtended.csv')\n",
+    "orig_salesforce = load_df('./Original/Salesforce - Accounts and Contacts.csv')\n",
+    "orig_volgistics = load_df('./Original/Volgistics - VolunteerInformation_Master.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### EDA for new data sources\n",
+    "\n",
+    "Before attempting matches, let's first understand the new data sources to extract the relevant fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "DEFAULT_PREVIEW_ROWS = 1  # number of records to preview, or 0 to disable (empty preview)\n",
+    "def preview_df(df):\n",
+    "    return df.head(DEFAULT_PREVIEW_ROWS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# First previewing some example data\n",
+    "orig_petpoint.pipe(preview_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "orig_salesforce.pipe(preview_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "orig_volgistics.pipe(preview_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Petpoint: (3122, 15)\n",
+      "Salesforce: (60187, 16)\n",
+      "Volgistics: (1242, 42)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# How big are the datasets?\n",
+    "print('Petpoint: {}'.format(orig_petpoint.shape))\n",
+    "print('Salesforce: {}'.format(orig_salesforce.shape))\n",
+    "print('Volgistics: {}'.format(orig_volgistics.shape))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# By going through the `orig_volgistics.columns`, etc., what are the minimal datasets we need?\n",
+    "petpoint = (\n",
+    "    orig_petpoint\n",
+    "    [['outcome_person_name', 'out_email', 'outcome_person_#']]\n",
+    "    .rename(columns={'outcome_person_name': 'petpoint_name', 'out_email': 'petpoint_email', 'outcome_person_#': 'petpoint_id'})\n",
+    "    .assign(lower_email=lambda df: df['petpoint_email'].str.lower())\n",
+    ")\n",
+    "salesforce = (\n",
+    "    orig_salesforce\n",
+    "    [['first_name', 'last_name', 'email', 'contact_id']]\n",
+    "    # contact_id=person in Salesforce nonprofit, account_id=household\n",
+    "    .assign(salesforce_name=lambda df: df['first_name'] + ' ' + df['last_name'])\n",
+    "    #.drop(columns=['first_name', 'last_name'])  # TODO: RE-ENABLE\n",
+    "    .rename(columns={'contact_id': 'salesforce_contact_id', 'email': 'salesforce_email'})  # 'account_id': 'sf_account_id'\n",
+    "    .assign(lower_email=lambda df: df['salesforce_email'].str.lower())\n",
+    ")\n",
+    "volgistics = (\n",
+    "    orig_volgistics\n",
+    "    [['first_name_last_name', 'email', 'number']]\n",
+    "    .rename(columns={'first_name_last_name': 'volgistics_name', 'number': 'volgistics_id', 'email': 'volgistics_email'})\n",
+    "    .assign(lower_email=lambda df: df['volgistics_email'].str.lower())\n",
+    ")  # note there are other interesting name fields available, such as nickname"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Petpoint: all rows (3122) vs. unique ID's (2746) vs. unique email (2642) vs. unique name+email (2745)\n",
+      "Volgistics: all rows (1242) vs. unique ID's (1242) vs. unique email (1239) vs. unique name+email (1242)\n",
+      "Salesforce: all rows (60187) vs. unique ID's (60187) vs. unique email (45418) vs. unique name+email (59665)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# How many unique columns in each dataset, first by the ID's and then by name+email.  How do they compare?\n",
+    "# vs. the raw shape of the dataframes above?\n",
+    "print(\"Petpoint: all rows ({}) vs. unique ID's ({}) vs. unique email ({}) vs. unique name+email ({})\".format(\n",
+    "    petpoint.shape[0], petpoint['petpoint_id'].nunique(), petpoint['petpoint_email'].nunique(), petpoint[['petpoint_name', 'petpoint_email']].drop_duplicates().shape[0]\n",
+    "))  # petpoint has multiple adoptions \n",
+    "print(\"Volgistics: all rows ({}) vs. unique ID's ({}) vs. unique email ({}) vs. unique name+email ({})\".format(\n",
+    "    volgistics.shape[0], volgistics['volgistics_id'].nunique(), volgistics['volgistics_email'].nunique(), volgistics[['volgistics_name', 'volgistics_email']].drop_duplicates().shape[0]\n",
+    "))\n",
+    "print(\"Salesforce: all rows ({}) vs. unique ID's ({}) vs. unique email ({}) vs. unique name+email ({})\".format(\n",
+    "    salesforce.shape[0], salesforce['salesforce_contact_id'].nunique(), salesforce['salesforce_email'].nunique(), salesforce[['salesforce_name', 'salesforce_email']].drop_duplicates().shape[0]\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing the original business rules\n",
+    "\n",
+    "How effective is email?  Email + fuzzy name?  Is there a particular threshold we should use?\n",
+    "\n",
+    "### Email uniqueness exploration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>volgistics_name</th>\n",
+       "      <th>volgistics_email</th>\n",
+       "      <th>volgistics_id</th>\n",
+       "      <th>lower_email</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [volgistics_name, volgistics_email, volgistics_id, lower_email]\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Before starting the email join, how unique is the field?  How many duplicates?\n",
+    "duplicate_volgistics_emails = volgistics.groupby('lower_email').count().reset_index().query(\"volgistics_id > 1\")\n",
+    "volgistics[volgistics['lower_email'].isin(duplicate_volgistics_emails['lower_email'])]\n",
+    "# Only three examples where the emails are nonunique, for review later"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([12,  8,  5,  5,  5], dtype=int64)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Also some emails in salesforce are repeated several times\n",
+    "orig_salesforce['email'].value_counts().head().values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# In the original iteration, we also found that there were a number of names that were fully uppercase in\n",
+    "# Salesforce and/or volgistics, so let's run the standardization there as well when we do the fuzzy scores"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### volgistics-salesforce matching"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Flagging the volgistics duplicate emails for separate data cleanup\n",
+    "excluded_volgistics = volgistics[volgistics['lower_email'].isin(duplicate_volgistics_emails['lower_email'])].copy()\n",
+    "volgistics = volgistics[~volgistics['lower_email'].isin(duplicate_volgistics_emails['lower_email'])]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Then, based on the number of unique emails, the business logic for Volgistics looks like it should be pretty straightforward\n",
+    "volgistics_match = salesforce.merge(volgistics[['lower_email', 'volgistics_id', 'volgistics_name']], how='inner')\n",
+    "volgistics_match.shape\n",
+    "\n",
+    "# Which emails do not match?\n",
+    "unmatched_volgistics = volgistics[~volgistics['lower_email'].isin(list(salesforce['lower_email']))]\n",
+    "unmatched_volgistics.head()\n",
+    "'hiding personal info';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "volgistics_match.head(10)\n",
+    "'hiding personal info';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# showing a specific email example without saying it directly here.\n",
+    "# Presumably a name change plus a couple that is sharing an email address\n",
+    "orig_salesforce[orig_salesforce['email'] == volgistics_match['salesforce_email'][4]]\n",
+    "'hiding personal info';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "volgistics_match['salesforce_name'] = volgistics_match['salesforce_name'].str.upper()\n",
+    "volgistics_match['volgistics_name'] = volgistics_match['volgistics_name'].str.upper()\n",
+    "volgistics_match['volgistics_fuzzy_name'] = df_fuzzy_score(volgistics_match, 'volgistics_name', 'salesforce_name')\n",
+    "volgistics_match.head()\n",
+    "'hiding personal info';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1211/1304 names have a 100% fuzzy match score for volgistics-salesforce\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"{}/{} names have a 100% fuzzy match score for volgistics-salesforce\".format(\n",
+    "    volgistics_match[volgistics_match['volgistics_fuzzy_name']==100].shape[0], volgistics_match.shape[0]\n",
+    "))\n",
+    "# WARNING: this number is greater than the {} records in the original volgistics dataset,\n",
+    "# because some rows have become duplicates due to emails with multiple rows in Salesforce.\n",
+    "# See the block before last for more details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "volgistics_matched_emails_not_names = (\n",
+    "    volgistics_match\n",
+    "    [volgistics_match['volgistics_fuzzy_name']!=100]\n",
+    "    .sort_values('volgistics_fuzzy_name')\n",
+    ")\n",
+    "# Lots to look on here about mismatching names to feed back for manual analysis, starting in priority order.\n",
+    "# Many are nicknames, duplicates in the Salesforce record (see next block), name changes, middle names, etc.\n",
+    "\n",
+    "volgistics_matched_emails_not_names\n",
+    "'hiding personal info';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "email_that_repeats_four_times = volgistics_matched_emails_not_names['salesforce_email'].value_counts().reset_index()['index'][0]\n",
+    "volgistics[volgistics['volgistics_email'] == email_that_repeats_four_times]\n",
+    "orig_salesforce[orig_salesforce['email'] == email_that_repeats_four_times]\n",
+    "# four individual tickets for the same event in Salesforce\n",
+    "'hiding personal info';"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### petpoint-salesforce matching"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Petpoint: all rows (3122) vs. unique ID's (2746) vs. unique email (2642) vs. unique name+email (2745)\n",
+      "Number of unique ID + email + name combinations: 2746\n"
+     ]
+    }
+   ],
+   "source": [
+    "# First, recalling the uniqueness situation from above:\n",
+    "print(\"Petpoint: all rows ({}) vs. unique ID's ({}) vs. unique email ({}) vs. unique name+email ({})\".format(\n",
+    "    petpoint.shape[0], petpoint['petpoint_id'].nunique(), petpoint['petpoint_email'].nunique(), petpoint[['petpoint_name', 'petpoint_email']].drop_duplicates().shape[0]\n",
+    "))  # petpoint has multiple adoptions\n",
+    "\n",
+    "# Hypothesis: the unique ID will map 1:1 to name+email since the original ID field was labeled as `outcome_person_#`\n",
+    "print(\"Number of unique ID + email + name combinatios: {}\". format(petpoint[['petpoint_name', 'petpoint_email', 'petpoint_id']].drop_duplicates().shape[0]))\n",
+    "# Since the number of unique ID's matches the number of unique ID's + emails + names in the dataset, each ID\n",
+    "# has a single value for email and name, meaning that we can simplify the petpoint dataframe to remove the duplicate rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2746, 4)"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "petpoint = petpoint.drop_duplicates()\n",
+    "petpoint.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1347993, 8)"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Then implement matching logic similar to the salesforce-volgistics joining\n",
+    "petpoint_match = salesforce.merge(petpoint[['lower_email', 'petpoint_id', 'petpoint_name']], how='inner')\n",
+    "petpoint_match.shape\n",
+    "\n",
+    "# This did not work (way too many matches)...presence of NULLs due to the pandas convention of treating those with\n",
+    "# NULL == NULL as True?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of petpoint IDs without an email: 99 out of 2746\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Number of petpoint IDs without an email: {} out of {}\".format(petpoint['lower_email'].isnull().sum(), petpoint.shape[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Filtering out petpoint ID's without an associated email address for further analysis\n",
+    "petpoint_no_email = petpoint[petpoint['lower_email'].isnull()].copy()\n",
+    "petpoint = petpoint[~petpoint['lower_email'].isnull()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1791, 8)\n",
+      "895 unmatched records from petpoint that have emails not in salesforce\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Then, trying the petpoint/salesforce match again\n",
+    "petpoint_match = salesforce.merge(petpoint[['lower_email', 'petpoint_id', 'petpoint_name']], how='inner')\n",
+    "print(petpoint_match.shape)\n",
+    "\n",
+    "# Which emails do not match?\n",
+    "unmatched_petpoint = petpoint[~petpoint['lower_email'].isin(list(salesforce['lower_email']))]\n",
+    "#unmatched_petpoint.head()\n",
+    "print(\"{} unmatched records from petpoint that have emails not in salesforce\".format(unmatched_petpoint.shape[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# We'll need to figure out what to do with the ~1/3 of emails that are in petpoint but not salesforce.\n",
+    "# In the meantime, how do the names match up between the two systems, assuming the emails match and are accurate?\n",
+    "\n",
+    "# Assiging fuzzy scores, closely following the same procedure as volgistics from above\n",
+    "petpoint_match['salesforce_name'] = petpoint_match['salesforce_name'].str.upper()\n",
+    "petpoint_match['petpoint_name'] = petpoint_match['petpoint_name'].str.upper()\n",
+    "petpoint_match['petpoint_fuzzy_name'] = df_fuzzy_score(petpoint_match, 'petpoint_name', 'salesforce_name')\n",
+    "petpoint_match.head()\n",
+    "'hiding personal info';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1673/1791 records with matching emails have a 100% fuzzy match score on names for petpoint-salesforce\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"{}/{} records with matching emails have a 100% fuzzy match score on names for petpoint-salesforce\".format(\n",
+    "    petpoint_match[petpoint_match['petpoint_fuzzy_name']==100].shape[0], petpoint_match.shape[0]\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "petpoint_matched_emails_not_names = (\n",
+    "    petpoint_match\n",
+    "    [petpoint_match['petpoint_fuzzy_name']!=100]\n",
+    "    .sort_values('petpoint_fuzzy_name')\n",
+    ")\n",
+    "# Lots to look on here about mismatching names to feed back for manual analysis, starting in priority order.\n",
+    "# Many are nicknames, duplicates in the Salesforce record (see next block), name changes, middle names, etc.\n",
+    "\n",
+    "petpoint_matched_emails_not_names\n",
+    "'hiding personal info';"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exporting audit reports\n",
+    "\n",
+    "These tables should be exported (e.g. using pandas method `.to_csv()` for audit/debugging purposes.  They will also be important to feed into a UI to help understand the nonmatching data and improve the data quality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "excluded_volgistics;  # duplicate emails in the volgistics table, which are excluded for now in the current business logic\n",
+    "unmatched_volgistics;  # volgistics records without a matching salesforce email\n",
+    "volgistics_matched_emails_not_names[['salesforce_email', 'salesforce_name', 'volgistics_name', 'salesforce_contact_id', 'volgistics_id', 'volgistics_fuzzy_name']];  # fuzzy match scores for mismatching names with the same email\n",
+    "\n",
+    "petpoint_no_email[['petpoint_name', 'petpoint_id']];  # Petpoint entries without an email address\n",
+    "unmatched_petpoint;  # petpoint records with an email address not found in salesforce\n",
+    "petpoint_matched_emails_not_names[['salesforce_email', 'salesforce_name', 'petpoint_name', 'salesforce_contact_id', 'petpoint_id', 'petpoint_fuzzy_name']];  # fuzzy match scores for petpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# And the good matches towards the master table, keeping in mind that some rows may be duplicates for people\n",
+    "# with the same email (and possibly name) depending on how they're entered into salesforce\n",
+    "volgistics_match[['salesforce_name', 'salesforce_email', 'salesforce_contact_id', 'volgistics_id']];\n",
+    "petpoint_match[['salesforce_name', 'salesforce_email', 'salesforce_contact_id', 'petpoint_id']];"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Using an extract from PAWS for volgistics, salesforce, and petpoint data to determine the suitability of the email + fuzzy matched names for joining the data sources together.

From the analysis, it appears that case-insensitive email can match the majority of records from the three datasets.  Fuzzy matching may not be necessary at all: there are ~100 records from each dataset with matching emails but mismatched names, which should be reasonable to manually curate the data and/or flag the matching records by hand (closes #9).  See notebook for additional details and steps for discussion and future work next week.