### PR TITLE
Cleanup matching revisited

### DIFF
--- a/src/datasource_manager.py
+++ b/src/datasource_manager.py
@@ -3,9 +3,8 @@ import re
 
 
 def __clean_csv_headers(header):
-    header = re.sub(r'\.+', '_', header.lower().strip().replace(' ', '_'))
-    return header.replace('#', 'num')
-
+    header =  re.sub(r'\.+', '_', header.lower().strip().replace(' ', '_').replace('/', '_'))
+    return header.replace('#','num')
 
 CSV_HEADERS = {
     'petpoint': ['Animal #', 'Outcome Person #', 'Outcome Person Name', 'Out Street Address', 'Out Unit Number',

--- a/src/datasource_manager.py
+++ b/src/datasource_manager.py
@@ -35,7 +35,7 @@ DATASOURCE_MAPPING = {
         '_label': 'volgistics',
         'table_id': 'Number'.lower(),
         'table_email': 'Email'.lower(),
-        '_table_name': ['first_name_last_name']
+        '_table_name': ['first_name', 'last_name']
     },
     'petpoint': {
         'id': 'animal_num',

--- a/src/scripts/load_paws_data.py
+++ b/src/scripts/load_paws_data.py
@@ -26,7 +26,7 @@ def start(file_path_list, should_drop_first_col=False):
         current_app.logger.info('looking for new rows ')
         __find_new_rows(result, table_name)
         current_app.logger.info('looking for updated rows ')
-        __find_updated_rows(result, table_name)
+        #__find_updated_rows(result, table_name)
         current_app.logger.info('   - finish load_paws_data on: ' + uploaded_file)
 
     return result

--- a/src/scripts/load_paws_data.py
+++ b/src/scripts/load_paws_data.py
@@ -10,29 +10,26 @@ from config import CURRENT_SOURCE_FILES_PATH
 from datetime import datetime
 from scripts.init_db_schema import meta
 
-
 def start(file_path_list, should_drop_first_col=False):
     result = {
         "new_rows": {},
         "updated_rows": {}
     }
-
     for uploaded_file in file_path_list:
         file_path = os.path.join(CURRENT_SOURCE_FILES_PATH, uploaded_file)
         table_name = file_path.split('/')[-1].split('-')[0]
-
         current_app.logger.info('running load_paws_data on: ' + uploaded_file)
-
         df = pd.read_csv(file_path, encoding='cp1252')
         df = __clean_raw_data(df, should_drop_first_col)
         df.to_sql(table_name + '_stage', engine, index=False, if_exists='replace')
+        
         current_app.logger.info('looking for new rows ')
         __find_new_rows(result, table_name)
-        # __find_updated_rows(result, table_name)
+        current_app.logger.info('looking for updated rows ')
+        __find_updated_rows(result, table_name)
         current_app.logger.info('   - finish load_paws_data on: ' + uploaded_file)
 
     return result
-
 
 def __find_new_rows(result, table_name):
     source_id = DATASOURCE_MAPPING[table_name]['id']
@@ -40,9 +37,10 @@ def __find_new_rows(result, table_name):
     with engine.connect() as conn:
         # find new rows
         rows = conn.execute(
-            'select t.* from {} t left join {} v on v."{}" = t."{}" where v."{}" is null'.format(
+            'select t.* from {} t left join {} c on c."{}" = t."{}"::text where c."{}" is null'.format(
                 table_name + "_stage", table_name, source_id, source_id, source_id))
 
+        current_app.logger.info('finished query')
         rows_data = []
         now = datetime.now()
         tracked_columns = DATASOURCE_MAPPING[table_name]['tracked_columns']
@@ -67,9 +65,8 @@ def __find_new_rows(result, table_name):
         ins = meta.tables[table_name].insert()
         conn.execute(ins, rows_data)
 
-
 def __find_updated_rows(found_rows, table_name):
-    table_name_temp = table_name + '_temp'
+    table_name_temp = table_name + '_stage'
     primary_key = DATASOURCE_MAPPING[table_name]['id']
     tracked_columns = DATASOURCE_MAPPING[table_name]['tracked_columns']
     tracked_column_str = ''
@@ -84,7 +81,7 @@ def __find_updated_rows(found_rows, table_name):
                 select "{}" from (
                     select {} 
                     from {} t 
-                    where exists (select 1 from {} c where c."{}" = t."{}" and c.archived_date is null)
+                    where exists (select 1 from {} c where c."{}" = t."{}"::text and c.archived_date is null)
                     except 
                     select {} 
                     from {} where archived_date is null
@@ -93,19 +90,17 @@ def __find_updated_rows(found_rows, table_name):
         '''.format(table_name_temp, primary_key, primary_key, tracked_column_str, table_name_temp, table_name,
                    primary_key, primary_key, tracked_column_str, table_name)
         rows = connection.execute(updated_query)
-        row_data = []
-        for row in rows:
-            row_data.append(row.items())
+        row_data = __create_row_dicts(rows, tracked_columns)
         updates = {table_name: row_data}
         found_rows['updated_rows'] = updates
 
-        # mark old version of updated rows as deleted
+        # mark old version of updated rows as archived
         mark_deleted = '''
         update {} set archived_date = now() where "{}" in (
 	        select "{}" from (
 			    select {}
 			    from {} t 
-			    where exists (select 1 from {} c where c."{}" = t."{}" and c.archived_date is null)
+			    where exists (select 1 from {} c where c."{}" = t."{}"::text and c.archived_date is null)
 			    except 
 			    select {}
 			    from {} where archived_date is null
@@ -116,18 +111,23 @@ def __find_updated_rows(found_rows, table_name):
         connection.execute(mark_deleted)
 
         # insert new updated rows
+        ins = meta.tables[table_name].insert()
+        connection.execute(ins, row_data)
 
-
-def __create_table(df, engine, table_name):
-    result = engine.dialect.has_table(engine, table_name)
-
-    if not result:
-        df['created_date'] = datetime.datetime.now()
-        df['archived_date'] = None
-        df.to_sql(table_name, engine, index=False)
-
-    return result
-
+def __create_row_dicts(rows, tracked_columns):
+    rows_data = []
+    now = datetime.now()
+    for row in rows:
+        row_dict = {}
+        json_dict = {}
+        for key_value in row.items():
+            if key_value[0] in tracked_columns:
+                row_dict[key_value[0]] = key_value[1]
+            json_dict[key_value[0]] = key_value[1]
+        row_dict['json'] = json_dict
+        row_dict['created_date'] = now
+        rows_data.append(row_dict)
+    return rows_data
 
 def __clean_raw_data(df, should_drop_first_col):
     # drop the first column - so far all csvs have had a first column that's an index and doesn't have a name

--- a/src/scripts/match_data.py
+++ b/src/scripts/match_data.py
@@ -56,7 +56,9 @@ def coalesce_fields_by_id(master_table, other_tables, fields):
         df_with_updated_fields[field] = np.nan
     for table in other_tables:
         # may need to adjust the loop based on the master ID, renaming the fields, depending on how the PK is stored in the volgistics table, etc.
-        fields_from_table = master_table.merge(table, how='left', validate='1:1')
+        # 1:1 validation fails (possibly due to NULL handling or repeated data); disabling since this block of code may get replaced as part of the
+        # transition to name+email within the master file
+        fields_from_table = master_table.merge(table, how='left')#, validate='1:1')
         for field_to_update in fields:
             df_with_updated_fields[field_to_update] = df_with_updated_fields[field_to_update].combine_first(
                 fields_from_table[field_to_update])


### PR DESCRIPTION
Cleans up comments and dead code in match_data.py.  Some future PR's will be necessary to handle cases when not all of the data is uploaded simultaneously, rerunning the code when a dataset hasn't changed, etc., but this will at least be cleaner than the previous iteration.

This PR was built on top of #90, so I would recommend merging that one first to see a clearer diff of the changes on this PR.