### PR TITLE
Fix for 180: missing  pdp_user_roles table

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -12,9 +12,6 @@ services:
       POSTGRES_PASSWORD: thispasswordisverysecure
       POSTGRES_DB: paws
 
-
-
-
   server:
     container_name: paws-compose-server
     build: ./server
@@ -27,7 +24,6 @@ services:
     environment: 
       FLASK_ENV: development
 
-
   client:
     build: ./client
     container_name: paws-compose-client
@@ -38,21 +34,6 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
     stdin_open: true
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 #using named volumes fixs a windows docker bug relating to container permissions

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       - postgres:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: thispasswordisverysecure
+      POSTGRES_DB: paws
+
+
+
 
   server:
     container_name: paws-compose-server
@@ -35,8 +39,27 @@ services:
       - CHOKIDAR_USEPOLLING=true
     stdin_open: true
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #using named volumes fixs a windows docker bug relating to container permissions
 #https://stackoverflow.com/questions/49148754/docker-container-shuts-down-giving-data-directory-has-wrong-ownership-error-wh
 volumes:
   postgres:
   src_archive:
+
+
+

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -39,5 +39,6 @@ WORKDIR /app
 
 RUN set FLASK_APP=server/app.py
 RUN export FLASK_APP
-# CMD alembic upgrade head ; python -m flask run --host=0.0.0.0
-CMD /app/start_server.sh
+
+# This abomination ensures that the PG server has finished its restart cycle
+CMD echo "SLEEPING 10"; sleep 10; echo "WAKING"; alembic upgrade head ; python -m flask run --host=0.0.0.0

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -39,4 +39,5 @@ WORKDIR /app
 
 RUN set FLASK_APP=server/app.py
 RUN export FLASK_APP
-CMD alembic upgrade head ; python -m flask run --host=0.0.0.0
+# CMD alembic upgrade head ; python -m flask run --host=0.0.0.0
+CMD /app/start_server.sh

--- a/src/server/start_server.sh
+++ b/src/server/start_server.sh
@@ -1,6 +1,0 @@
-echo "Sleeping for 10s..."  
-sleep 10    
-echo "Running Alembic"   
-alembic upgrade head   
-echo "Starting Flask"  
-python -m flask run --host=0.0.0.0

--- a/src/server/start_server.sh
+++ b/src/server/start_server.sh
@@ -1,0 +1,6 @@
+echo "Sleeping for 10s..."  
+sleep 10;    
+echo "Running Alembic";   
+alembic upgrade head;   
+echo "Starting Flask"  
+python -m flask run --host=0.0.0.0

--- a/src/server/start_server.sh
+++ b/src/server/start_server.sh
@@ -1,6 +1,6 @@
 echo "Sleeping for 10s..."  
-sleep 10;    
-echo "Running Alembic";   
-alembic upgrade head;   
+sleep 10    
+echo "Running Alembic"   
+alembic upgrade head   
 echo "Starting Flask"  
 python -m flask run --host=0.0.0.0


### PR DESCRIPTION
This is a work-around for the race condition discussed in #180. 

In `docker-compose.yml`, added creation of the `paws` DB at container start.

In the server `Dockerfile`, added a 10s delay before the Alembic operation runs. 

@dkelley we should review how your nginx starup interacts with this in your #175