### PR TITLE
Write original input data to pdp_contacts json

### DIFF
--- a/src/server/models.py
+++ b/src/server/models.py
@@ -1,4 +1,5 @@
 import datetime
+import copy
 
 from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.dialects.postgresql import JSONB
@@ -26,6 +27,10 @@ class PdpContacts(Base):
     json = Column(JSONB)
     created_date = Column(DateTime, default=datetime.datetime.utcnow)
     archived_date = Column(DateTime, default=None)
+
+
+TempPdpContactsLoader = copy.deepcopy(PdpContacts)
+TempPdpContactsLoader.__tablename__ = "_temp_pdp_contacts_loader"
 
 
 

--- a/src/server/pipeline/flow_script.py
+++ b/src/server/pipeline/flow_script.py
@@ -45,6 +45,7 @@ def start_flow():
 
             # Copy raw input rows to json fields in pdp_contacts,
             # using a temporary table to simplify the update code.
+            current_app.logger.info('Saving json of original rows to pdp_contacts')
             source_json.to_sql('_temp_pdp_contacts_loader', connection, index=False, if_exists='replace')
             # https://www.postgresql.org/docs/8.4/sql-update.html
             connection.execute('''
@@ -56,4 +57,6 @@ def start_flow():
                     pdp.source_id = temp.source_id AND
                     pdp.archived_date IS NULL
             ''')
+
+            current_app.logger.info('Finished flow script run')
 


### PR DESCRIPTION
Closes #177

The json field in pdp_contacts is now being populated with the original data from the source information from salesforce, volgistics, etc. This will enable queries to extract information from other non-contact fields, such as lifetime volunteer hours, from these primary tables.

For active (non-archived) rows, the binary json field will be updated on every run with the latest version of available data.