### PR TITLE
Improved login robustness

### DIFF
--- a/src/server/api/user_api.py
+++ b/src/server/api/user_api.py
@@ -108,14 +108,21 @@ def user_login_json():
         Expects json-encoded form data
     """
 
+    def dummy_check():
+        """Perform a fake password hash check to take as much time as a real one."""
+        pw_bytes = bytes('password', "utf8")
+        check_password('password', pw_bytes)
+
     try:
         post_dict = json.loads(request.data)
         username = post_dict["username"]
         presentedpw = post_dict["password"]
     except:
+        dummy_check()    # Take the same time as with well-formed requests 
         return jsonify("Bad credentials"), 401
 
     if not (isinstance(username, str) and isinstance(presentedpw, str) ):
+        dummy_check()  # Take the same time as with well-formed requests 
         return jsonify("Bad credentials"), 401   # Don't give us ints, arrays, etc.
 
 

--- a/src/server/api/user_api.py
+++ b/src/server/api/user_api.py
@@ -108,6 +108,7 @@ def user_login_json():
             pwhash, role, is_active = result.fetchone()
         else:
             log_user_action(username, "Failure", "Invalid username")
+            dummy_check()
             return jsonify("Bad credentials"), 401
 
         if is_active.lower() == "y" and check_password(presentedpw, pwhash):

--- a/src/server/api/user_api.py
+++ b/src/server/api/user_api.py
@@ -108,9 +108,16 @@ def user_login_json():
         Expects json-encoded form data
     """
 
-    post_dict = json.loads(request.data)
-    username = post_dict["username"]
-    presentedpw = post_dict["password"]
+    try:
+        post_dict = json.loads(request.data)
+        username = post_dict["username"]
+        presentedpw = post_dict["password"]
+    except:
+        return jsonify("Bad credentials"), 401
+
+    if not (isinstance(username, str) and isinstance(presentedpw, str) ):
+        return jsonify("Bad credentials"), 401   # Don't give us ints, arrays, etc.
+
 
     with engine.connect() as connection:
 

--- a/src/server/api/user_api.py
+++ b/src/server/api/user_api.py
@@ -119,6 +119,7 @@ def user_login_json():
 
         else:
             log_user_action(username, "Failure", "Bad password or inactive")
+            # No dummy_check needed as we ran a real one to get here
             return jsonify("Bad credentials"), 401
 
 


### PR DESCRIPTION
`user_api/login_json()` would throw exceptions and 500 errors for badly-formed request bodies. These changes validate that the expected parameters are present and that they are JSON strings. Should either of those tests fail, I added a dummy password hash check so that badly-formed bodies requests take as long to return as well-formed ones.  There's also a dummy_check if username is invalid, since we won't be checking the password. We don't need one if the password was bad becuse we had to run the hash function to find that out.

See Slack #pdp_dev for Postman config to test.

Closes #193