### PR TITLE
Update app.py to set logging level to INFO

### DIFF
--- a/src/server/app.py
+++ b/src/server/app.py
@@ -25,6 +25,9 @@ app.register_blueprint(admin_api)
 app.register_blueprint(common_api)
 app.register_blueprint(user_api)
 
+app.logger.setLevel('INFO')  # By default, Docker appears to set at INFO but VSCode at WARNING 
+
+
 # init_db_schema.start(connection)
 
 


### PR DESCRIPTION
Explicitly set logging level to INFO (most verbose). In Docker, this seems to get set to INFO, but when running it VSCode it seems to be set to WARNING, so we miss a lot of messages.