### PR TITLE
Removes use and dependency on sqlalchemy_utils

### DIFF
--- a/src/server/config.py
+++ b/src/server/config.py
@@ -1,6 +1,5 @@
 import os
 import sqlalchemy as db
-from sqlalchemy_utils import database_exists, create_database
 
 import models
 
@@ -38,9 +37,6 @@ else:
     )
 
 engine = db.create_engine(DB)
-
-if not database_exists(engine.url):
-    create_database(engine.url)
 
 with engine.connect() as connection:
     models.Base.metadata.create_all(connection)

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -3,7 +3,6 @@ pandas==1.0.0
 numpy==1.18.1
 fuzzywuzzy==0.17.0
 sqlalchemy < 1.4.0   # Import error with 1.4.0 on _ColumnEntity
-sqlalchemy_utils
 psycopg2-binary==2.8.4
 python-Levenshtein-wheels
 xlrd==1.2.0  # currently used for xlsx, but we should consider adjusting code to openpyxl for xlsx


### PR DESCRIPTION
Only used to test if 'paws' db exists and to create it if not, but already
 being created in docker-compose.yml (since https://github.com/CodeForPhilly/paws-data-pipeline/commit/5367ffeba53c5d59710648fd1f1b2f0d635489ee).

This will allow us to to remove the restriction keeping  SQLAlchemy below 1.4 (once tested).  