### PR TITLE
Improved secrets handling for deployment

### DIFF
--- a/src/server/alembic.ini
+++ b/src/server/alembic.ini
@@ -36,7 +36,7 @@ script_location = alembic
 # output_encoding = utf-8
 
 # Container
-sqlalchemy.url = postgresql://postgres:thispasswordisverysecure@paws-compose-db/paws
+sqlalchemy.url = postgresql://postgres:PASSWORD@paws-compose-db/paws
 
 # Local
 # sqlalchemy.url = postgresql://postgres:thispasswordisverysecure@localhost/paws

--- a/src/server/alembic/env.py
+++ b/src/server/alembic/env.py
@@ -3,6 +3,8 @@ from logging.config import fileConfig
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
+from os import environ
+
 from alembic import context
 
 # this is the Alembic Config object, which provides
@@ -25,6 +27,13 @@ target_metadata = None
 # ... etc.
 
 
+PG_URL1 = 'postgresql://postgres:'
+PG_URL2 = environ['POSTGRES_PASSWORD']
+PG_URL3 = '@paws-compose-db/paws'
+
+PG_URL = PG_URL1 + PG_URL2 + PG_URL3
+
+
 def run_migrations_offline():
     """Run migrations in 'offline' mode.
 
@@ -37,7 +46,8 @@ def run_migrations_offline():
     script output.
 
     """
-    url = config.get_main_option("sqlalchemy.url")
+    # url = config.get_main_option("sqlalchemy.url")
+    url = PG_URL
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -60,6 +70,7 @@ def run_migrations_online():
         config.get_section(config.config_ini_section),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        url=PG_URL,
     )
 
     with connectable.connect() as connection:

--- a/src/server/api/common_api.py
+++ b/src/server/api/common_api.py
@@ -7,7 +7,23 @@ import json
 import time
 from datetime import datetime
 import dateutil.parser
-from secrets import SHELTERLUV_SECRET_TOKEN
+
+
+try:   
+    from secrets import SHELTERLUV_SECRET_TOKEN
+except ImportError:   
+    # Not running locally
+    print("Couldn't get SL_TOKEN from file, trying environment **********")
+    from os import environ
+
+    try:
+        SHELTERLUV_SECRET_TOKEN = environ['SHELTERLUV_SECRET_TOKEN']
+    except KeyError:
+        # Nor in environment
+        # You're SOL for now
+        print("Couldn't get secrets from file or environment")
+
+
 
 from api import jwt_ops
 

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -4,7 +4,21 @@ from flask import Flask
 
 from flask_jwt_extended import JWTManager
 
-from secrets import JWT_SECRET, APP_SECRET_KEY
+try:   
+    from secrets import JWT_SECRET, APP_SECRET_KEY
+except ImportError:   
+    # Not running locally
+    print("Could not get secrets from file, trying environment **********")
+    from os import environ
+
+    try:
+        JWT_SECRET = environ['JWT_SECRET']
+        APP_SECRET_KEY = environ['APP_SECRET_KEY']
+    except KeyError:
+        # Nor in environment
+        # You're SOL for now
+        print("Couldn't get secrets from file or environment")
+
 
 app = Flask(__name__)
 

--- a/src/server/bin/export_secrets.sh
+++ b/src/server/bin/export_secrets.sh
@@ -1,0 +1,7 @@
+set -o allexport
+ while read k _ v; 
+    do 
+      eval $k=$v;
+      export k;
+    done < 'secrets.py'
+ set +o allexport

--- a/src/server/bin/startServer.sh
+++ b/src/server/bin/startServer.sh
@@ -1,9 +1,10 @@
+#!/bin/bash
 
 # we may want to switch this to a script which logs output, etc?
 echo "------------STARTING `date` ------------------"
 set FLASK_APP=server/app.py
 export FLASK_APP
-
+source bin/export_secrets.sh
 # This abomination ensures that the PG server has finished its restart cycle
 echo "SLEEPING.. WAITING FOR DB"; sleep 5; echo "WAKING"; alembic upgrade head; echo "DB SETUP";
 #; python -m flask run --host=0.0.0.0 --no-reload

--- a/src/server/pipeline/shelterluv_api_handler.py
+++ b/src/server/pipeline/shelterluv_api_handler.py
@@ -1,7 +1,21 @@
 import requests
 import csv
 from config import RAW_DATA_PATH
-from secrets import SHELTERLUV_SECRET_TOKEN
+
+try:   
+    from secrets import SHELTERLUV_SECRET_TOKEN
+except ImportError:   
+    # Not running locally
+    print("Couldn't get SL_TOKEN from file, trying environment **********")
+    from os import environ
+
+    try:
+        SHELTERLUV_SECRET_TOKEN = environ['SHELTERLUV_SECRET_TOKEN']
+    except KeyError:
+        # Nor in environment
+        # You're SOL for now
+        print("Couldn't get secrets from file or environment")
+
 
 
 def write_csv(json_data):

--- a/src/server/user_mgmt/base_users.py
+++ b/src/server/user_mgmt/base_users.py
@@ -3,7 +3,25 @@ from config import engine
 from api import user_api
 import sqlalchemy as sa
 
-from secrets import BASEUSER_PW, BASEEDITOR_PW, BASEADMIN_PW
+try:   
+    from secrets import BASEUSER_PW, BASEEDITOR_PW, BASEADMIN_PW
+except ImportError:   
+    # Not running locally
+    print("Couldn't get BASE user PWs from file, trying environment **********")
+    from os import environ
+
+    try:
+        BASEUSER_PW = environ['BASEUSER_PW']
+        BASEEDITOR_PW = environ['BASEEDITOR_PW']
+        BASEADMIN_PW = environ['BASEADMIN_PW']
+
+    except KeyError:
+        # Nor in environment
+        # You're SOL for now
+        print("Couldn't get secrets from file or environment")
+
+
+
 
 
 from sqlalchemy import Table, Column, Integer, String, MetaData, ForeignKey


### PR DESCRIPTION
Because we can't include `secrets.py` file in public images (#271), added new script `server/bin/export_secrets.sh` that reads secrets file and exports to the environment.  The assumption is than on k8s we'll store secrets and expose as env_vars.

Alembic now gets DB password from environment, no longer hard-coded in `alembic.ini`  (#273)

Server code tries to import as before, then tries to get from environment. (#271)

To test locally

-  Rename `server\secrets.py` to `Xsecrets.py` 
-  Edit `bin\export_secrets.sh` to use that file name
-  Do `down -v` , build, up
-  Watch logs to see Alembic migrations run, base users created
-  Fix filenames!

Q:  Does it make sense to even keep the local import code (possibility of getting out of sync) or should I just set it to get vars from the environment always?  (If the file is present, the script will set them. If not, k8s will have done so.)

Resolves #271, #273