### PR TITLE
Updated to support SQL Alchemy 1.4

### DIFF
--- a/src/server/alembic/versions/f3d30db17bed_change_pdp_users_password_to_bytea.py
+++ b/src/server/alembic/versions/f3d30db17bed_change_pdp_users_password_to_bytea.py
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     op.drop_column("pdp_users", "password")
-    op.add_column("pdp_users", sa.Column("password", sa.Binary, nullable=False))
+    op.add_column("pdp_users", sa.Column("password", sa.LargeBinary, nullable=False))
 
 
 def downgrade():

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.2
 pandas==1.0.0
 numpy==1.18.1
-sqlalchemy < 1.4.0   # Import error with 1.4.0 on _ColumnEntity
+sqlalchemy==1.4.15 
 psycopg2-binary==2.8.4
 xlrd==1.2.0  # currently used for xlsx, but we should consider adjusting code to openpyxl for xlsx
 openpyxl


### PR DESCRIPTION
'Binary' had been deprecated  a long time in favor of 'LargeBinary', but support for the latter ended at 1.4.