### PR TITLE
fix bad matching

### DIFF
--- a/src/server/pipeline/match_data.py
+++ b/src/server/pipeline/match_data.py
@@ -62,11 +62,11 @@ def start(connection, added_or_updated_rows, manual_matches_df):
         # Exact matches based on specified columns
         row_matches = pdp_contacts[
             (
-                ((pdp_contacts["first_name_normalized"] == row["first_name_normalized"]) &
+                (((pdp_contacts["first_name_normalized"] == row["first_name_normalized"]) &
                 (pdp_contacts["last_name_normalized"] == row["last_name_normalized"]))
                 |
                 ((pdp_contacts["first_name_normalized"] == row["last_name_normalized"]) &
-                (pdp_contacts["last_name_normalized"] == row["first_name_normalized"]))
+                (pdp_contacts["last_name_normalized"] == row["first_name_normalized"])))
                 &
                 ((pdp_contacts["email_normalized"] == row["email_normalized"]) | (pdp_contacts["mobile"] == row["mobile"]))
             )


### PR DESCRIPTION
This was an order of operations issue. Below is the pseudo code for the matching logic: 

IF names_matched OR names_reversed_matched AND (email_matches or mobile_matched)

Boolean order of operations is:
1. NOT
2. AND
3. OR

Adding parentheses makes this more clear:

IF names_matched OR (names_reversed_matched AND (email_matches or mobile_matched))

So it was matching if either the names reversed matched and either email or mobile matched or first name and last name matched.