### PR TITLE
Redirect to origin, not '/'

### DIFF
--- a/src/server/api/admin_api.py
+++ b/src/server/api/admin_api.py
@@ -37,7 +37,7 @@ def upload_csv():
             finally:
                 file.close()
 
-    return redirect("/")
+    return redirect(request.origin)
 
 
 @admin_api.route("/api/listCurrentFiles", methods=["GET"])


### PR DESCRIPTION
To test , set port in `docker-compose.yml` to something other than 80:

```  client:
    build: ./client
    container_name: paws-compose-client
    ports:
      - "8000:80"`