### PR TITLE
Change /api/execute from GET to POST

### DIFF
--- a/src/client/src/pages/Admin.js
+++ b/src/client/src/pages/Admin.js
@@ -102,7 +102,7 @@ class Admin extends Component {
 
         await fetch('/api/execute',
             {
-                method: 'GET',
+                method: 'POST',
                 headers: {
                     'Authorization': 'Bearer ' + this.props.access_token
                 }

--- a/src/server/api/admin_api.py
+++ b/src/server/api/admin_api.py
@@ -54,7 +54,7 @@ def list_current_files():
     return jsonify(result)
 
 
-@admin_api.route("/api/execute", methods=["GET"])
+@admin_api.route("/api/execute", methods=["POST"])
 @jwt_ops.admin_required
 def execute():
     current_app.logger.info("Execute flow")


### PR DESCRIPTION
Changes  `/api/execute` from HTTP GET  to the more appropriate (and non-retryable) POST.

Closes #325 