### PR TITLE
322 - Quick and dirty logout

### DIFF
--- a/src/client/src/App.js
+++ b/src/client/src/App.js
@@ -5,6 +5,7 @@ import {BrowserRouter as Router, Switch, Route, useHistory, Redirect} from 'reac
 import Header, {AdminHeader, LoginHeader} from "./components/Header";
 
 import Login from './pages/Login/Login';
+import Logout from './pages/Login/Logout';
 import HomePage from './pages/Home';
 import Admin from './pages/Admin';
 import Search360 from './pages/DataView360/Search/Search';
@@ -140,6 +141,10 @@ function AuthenticatedApp() {
 
                         <Route path="/check">
                             <Check access_token={access_token}/>
+                        </Route>
+                        
+                        <Route path="/logout">
+                            <Logout setToken={setToken}/>
                         </Route>
 
                         <Route path="/ref">

--- a/src/client/src/components/Header.js
+++ b/src/client/src/components/Header.js
@@ -19,6 +19,7 @@ export function AdminHeader(props) {  // This one if user has the ADMIN role
                     <Button className={styles.header_link} component={RouterLink} to="/360view/search">360
                         DataView</Button>
                     <Button className={styles.header_link} component={RouterLink} to="/about">About us</Button>
+                    <Button className={styles.header_link} component={RouterLink} to="/logout">Log Out</Button>
                     { /* <Button className={styles.header_link} component={RouterLink} to="/check">Check</Button> */}
                 </div>
             </Toolbar>
@@ -52,6 +53,7 @@ export default function Header(props) {  // This one if user only has USER role 
                     <Button className={styles.header_link} component={RouterLink} to="/360view/search">360
                         DataView</Button>
                     <Button className={styles.header_link} component={RouterLink} to="/about">About us</Button>
+                    <Button className={styles.header_link} component={RouterLink} to="/logout">Log Out</Button>
                     { /* <Button className={styles.header_link} component={RouterLink} to="/check">Check</Button> */}
                 </div>
             </Toolbar>

--- a/src/client/src/pages/Login/Logout.js
+++ b/src/client/src/pages/Login/Logout.js
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useHistory } from "react-router-dom";
+
+
+export default function Logout({ setToken }) {
+    
+    setToken(null);
+    let history = useHistory();
+    history.push('/')
+
+    return (
+        <div></div>
+    )
+}
+
+Logout.propTypes = {
+    setToken: PropTypes.func.isRequired
+};

--- a/src/server/api/user_api.py
+++ b/src/server/api/user_api.py
@@ -186,10 +186,18 @@ def user_test_auth():
 @user_api.route("/api/user/logout", methods=["POST"])
 @jwt_ops.jwt_required()
 def user_logout():
-    username = request.form["username"]  # TODO: Should be JSON all throughout
+    
+    user_name = ''
+
+    old_jwt = jwt_ops.validate_decode_jwt()   
+
+    # If token bad, should be handled & error message sent by jwt_required() and we won't get here
+    if old_jwt:
+        user_name = old_jwt['sub']
+    
     # Log the request
-    log_user_action(username, "Success", "Logged out ")
-    return jsonify("Logged out " + username)
+    log_user_action(user_name, "Success", "Logged out")
+    return jsonify("Logged out")
 
 
 # Generate a new access token 


### PR DESCRIPTION
Logout.js deletes access_token and redirects to /.

On server, user_logout() gets the username from the JWT.  

As of https://github.com/CodeForPhilly/paws-data-pipeline/commit/ad7412540d22f950848803094131a48a79fb2c72 , the JS is not hitting the API endpoint due to hooks issues. User is logged out, but it's not logged in the user_journal.

Closes #322 