### PR TITLE
Volshifts insert

### DIFF
--- a/src/client/src/pages/DataView360/View/View360.js
+++ b/src/client/src/pages/DataView360/View/View360.js
@@ -17,7 +17,7 @@ import moment from 'moment';
 import Adoptions from './components/Adoptions';
 import ContactInfo from './components/ContactInfo';
 import Donations from './components/Donations';
-import Fosters from './components/Fosters';
+// import Fosters from './components/Fosters';
 import VolunteerActivity from './components/VolunteerActivity';
 import VolunteerHistory from './components/VolunteerHistory';
 import Box from "@material-ui/core/Box";
@@ -167,11 +167,11 @@ class View360 extends Component {
                                                     shelterluvShortId={_.get(this.state, 'participantData.shelterluvShortId')}
 
                                         />
-                                        <Fosters pets={_.get(this.state, 'animalData')}
+                                        {/* <Fosters pets={_.get(this.state, 'animalData')}
                                                     events={_.get(this.state, 'fosterEvents')}
                                                     headerText={"Foster Records"}
                                                     shelterluvShortId={_.get(this.state, 'participantData.shelterluvShortId')}
-                                        />
+                                        /> */}
                                         <VolunteerActivity volunteer={this.extractVolunteerActivity()} />
                                         <VolunteerHistory volunteerShifts={_.get(this.state, 'participantData.shifts')} />
                                     </Grid>

--- a/src/client/src/pages/DataView360/View/components/Donations.js
+++ b/src/client/src/pages/DataView360/View/components/Donations.js
@@ -33,7 +33,7 @@ class Donations extends Component {
         const result = _.map(latestDonations, (donation, index) => {
             return (<TableRow key={index}>
                 <TableCell>{donation.close_date}</TableCell>
-                <TableCell>${donation.amount}</TableCell>
+                <TableCell>${donation.amount.toFixed(2)}</TableCell>
                 <TableCell>{donation.type}</TableCell>
                 <TableCell>{donation.primary_campaign_source}</TableCell>
             </TableRow>);

--- a/src/client/src/pages/DataView360/View/components/VolunteerHistory.js
+++ b/src/client/src/pages/DataView360/View/components/VolunteerHistory.js
@@ -22,15 +22,15 @@ class VolunteerHistory extends Component {
     createShiftRows(shifts) {
         const shiftsFiltered = _.filter(shifts, function(s) { return s.from !== "Invalid date"});
         const shiftsSorted = _.sortBy(shiftsFiltered, shift => {
-            return new moment(shift.from).format("YYYY-MM-DD");
+            return new moment(shift.from_date).format("YYYY-MM-DD");
         }).reverse();
 
         const lastShifts = shiftsSorted.slice(0, SHIFTS_TO_SHOW)
         
         const result = _.map(lastShifts, (shift, index) => {
-            shift.from = moment(shift.from).format("YYYY-MM-DD")
+            shift.from_date = moment.utc(shift.from_date).format("YYYY-MM-DD")
             return(<TableRow key={index}>
-                    <TableCell>{shift.from}</TableCell>
+                    <TableCell>{shift.from_date}</TableCell>
                     <TableCell>{shift.assignment}</TableCell>
                 </TableRow>);
 

--- a/src/server/alembic/versions/d0841384d5d7_explicitly_create_vshifts.py
+++ b/src/server/alembic/versions/d0841384d5d7_explicitly_create_vshifts.py
@@ -1,0 +1,39 @@
+"""Explicitly create vshifts
+
+Revision ID: d0841384d5d7
+Revises: e3ef522bd3d9
+Create Date: 2021-07-05 22:05:52.743905
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd0841384d5d7'
+down_revision = 'e3ef522bd3d9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+   def upgrade():
+    op.create_table (
+        "volgisticsshifts",
+        sa.Column("_id", sa.Integer, primary_key=True),
+        sa.Column("volg_id", sa.Integer, nullable=False),
+        sa.Column("assignment", sa.String(), nullable=True),
+        sa.Column("from_date",  sa.Date, nullable=False),
+        sa.Column("hours",  sa.DECIMAL, nullable=False),
+
+    )
+
+    op.execute("""CREATE  INDEX vs_volg_id_idx 
+                    ON public.volgisticsshifts USING btree (volg_id);"""
+                    )
+
+    op.create_unique_constraint( "uq_shift", "volgisticsshifts",  ["volg_id", "assignment", "from_date", "hours"] ) 
+
+
+def downgrade():
+    op.drop_table("volgisticsshifts")

--- a/src/server/alembic/versions/d0841384d5d7_explicitly_create_vshifts.py
+++ b/src/server/alembic/versions/d0841384d5d7_explicitly_create_vshifts.py
@@ -17,15 +17,14 @@ depends_on = None
 
 
 def upgrade():
-   def upgrade():
     op.create_table (
         "volgisticsshifts",
         sa.Column("_id", sa.Integer, primary_key=True),
         sa.Column("volg_id", sa.Integer, nullable=False),
         sa.Column("assignment", sa.String(), nullable=True),
+        sa.Column("site", sa.String(), nullable=True),      
         sa.Column("from_date",  sa.Date, nullable=False),
-        sa.Column("hours",  sa.DECIMAL, nullable=False),
-
+        sa.Column("hours",  sa.DECIMAL, nullable=False)
     )
 
     op.execute("""CREATE  INDEX vs_volg_id_idx 

--- a/src/server/api/file_uploader.py
+++ b/src/server/api/file_uploader.py
@@ -12,6 +12,7 @@ from datasource_manager import DATASOURCE_MAPPING
 from openpyxl import load_workbook
 from tempfile import NamedTemporaryFile
 from donations_importer import validate_import_sfd
+from shifts_importer import validate_import_vs
 SUCCESS_MSG = 'Uploaded Successfully!'
 lock = threading.Lock()
 
@@ -36,7 +37,12 @@ def determine_upload_type(file, file_extension, destination_path):
             validate_import_sfd(file)
             return
         else:
-            dfs = excel_to_dataframes(file) #crs
+            match = re.search('volunteer', file.filename, re.I)
+            if match:
+                validate_import_vs(file)
+                return
+            else:
+                dfs = excel_to_dataframes(file) #crs
   
 
     found_sources = 0

--- a/src/server/api/file_uploader.py
+++ b/src/server/api/file_uploader.py
@@ -33,16 +33,16 @@ def determine_upload_type(file, file_extension, destination_path):
     else:
         
         match = re.search('donat', file.filename, re.I)
-        if match:   # It's a Sales Force Donations file
+        if match:   # It's a SalesForce Donations file
             validate_import_sfd(file)
             return
         else:
             match = re.search('volunteer', file.filename, re.I)
-            if match:
-                validate_import_vs(file)
-                return
+            if match:    # It's a Volgistics file
+                validate_import_vs(file)  
+                dfs = excel_to_dataframes(file)  # Also need to run Volgistics through match processing
             else:
-                dfs = excel_to_dataframes(file) #crs
+                dfs = excel_to_dataframes(file)   #  It's a non-Volgistics, non-Shelterluv XLS? file 
   
 
     found_sources = 0

--- a/src/server/datasource_manager.py
+++ b/src/server/datasource_manager.py
@@ -15,14 +15,19 @@ CSV_HEADERS = {
     'salesforcecontacts': ['Contact ID 18', 'First Name', 'Last Name', 'Mailing Street', 'Mailing City',
                            'Mailing State/Province', 'Mailing Zip/Postal Code', 'Mailing Country', 'Phone', 'Mobile',
                            'Email', 'Account ID 18', 'Volgistics ID', 'Person ID'],
-    # 'volgisticsshifts': ['Number', 'Place', 'Assignment', 'From date', 'To date', 'Hours'],
-    # 'salesforcedonations': ['Recurring donor', 'Opportunity Owner', 'Account Name', 'Opportunity ID (18 Digit)',
-    #                         'Account ID (18 digit)',
-    #                         'Opportunity Name', 'Stage', 'Fiscal Period', 'Amount', 'Probability (%)', 'Age',
-    #                         'Close Date', 'Created Date', 'Type', 'Primary Campaign Source',
-    #                         'Source', 'Contact ID (18 Digit)', 'Primary Contact'],
+    'volgisticsshifts': ['Number', 'Place', 'Assignment', 'From date', 'To date', 'Hours'],
+    'salesforcedonations': ['Recurring donor', 'Opportunity Owner', 'Account Name', 'Opportunity ID (18 Digit)',
+                            'Account ID (18 digit)',
+                            'Opportunity Name', 'Stage', 'Fiscal Period', 'Amount', 'Probability (%)', 'Age',
+                            'Close Date', 'Created Date', 'Type', 'Primary Campaign Source',
+                            'Source', 'Contact ID (18 Digit)', 'Primary Contact'],
     'manualmatches': ['salesforcecontacts', 'volgistics', 'shelterluvpeople']
 }
+
+    # TODO: Now that volgisticsshifts and salesforcedonations are loaded directly, what should their records above and below reflect 
+    #       to be processed by clean_and_load_data  (L34) ? 
+
+
 
 DATASOURCE_MAPPING = {
     'salesforcecontacts': {
@@ -50,23 +55,23 @@ DATASOURCE_MAPPING = {
         '_table_name': ['Firstname'.lower(), 'Lastname'.lower()],
         'should_drop_first_column': False
     },
-    # 'volgisticsshifts': {
-    #     'id': 'number',
-    #     'csv_names': CSV_HEADERS['volgisticsshifts'],
-    #     'tracked_columns': list(map(__clean_csv_headers, CSV_HEADERS['volgisticsshifts'])),
-    #     'table_email': None,
-    #     '_table_name': None,
-    #     'sheetname': 'Service',
-    #     'should_drop_first_column': False
-    # },
-    # 'salesforcedonations': {
-    #     'id': 'contact_id',
-    #     'csv_names': CSV_HEADERS['salesforcedonations'],
-    #     'tracked_columns': list(map(__clean_csv_headers, CSV_HEADERS['salesforcedonations'])),
-    #     'table_email': None,
-    #     '_table_name': None,
-    #     'should_drop_first_column': True
-    # }
+    'volgisticsshifts': {
+        'id': 'volg_id',
+        'csv_names': CSV_HEADERS['volgisticsshifts'],
+        'tracked_columns': list(map(__clean_csv_headers, CSV_HEADERS['volgisticsshifts'])),
+        'table_email': None,
+        '_table_name': None,
+        'sheetname': 'Service',
+        'should_drop_first_column': False
+    },
+    'salesforcedonations': {
+        'id': 'contact_id',
+        'csv_names': CSV_HEADERS['salesforcedonations'],
+        'tracked_columns': list(map(__clean_csv_headers, CSV_HEADERS['salesforcedonations'])),
+        'table_email': None,
+        '_table_name': None,
+        'should_drop_first_column': True
+    }
 }
 
 

--- a/src/server/datasource_manager.py
+++ b/src/server/datasource_manager.py
@@ -120,12 +120,12 @@ SOURCE_NORMALIZATION_MAPPING = {
         }
 
     },
-    # "salesforcedonations": {
-    #     "parent": "salesforcecontacts",
-    #     "others": {
-    #         "should_drop_first_column": True
-    #     }
-    # },
+    "salesforcedonations": {
+        "parent": "salesforcecontacts",
+        "others": {
+            "should_drop_first_column": True
+        }
+    },
     "shelterluvpeople": {
         "source_id": "internal-id",
         "first_name": "firstname",
@@ -156,10 +156,10 @@ SOURCE_NORMALIZATION_MAPPING = {
             "should_drop_first_column": True
         }
     },
-    # "volgisticsshifts": {
-    #     "parent": "volgistics",
-    #     "others": {
-    #         "should_drop_first_column": True
-    #     }
-    # }
+    "volgisticsshifts": {
+        "parent": "volgistics",
+        "others": {
+            "should_drop_first_column": True
+        }
+    }
 }

--- a/src/server/datasource_manager.py
+++ b/src/server/datasource_manager.py
@@ -15,12 +15,12 @@ CSV_HEADERS = {
     'salesforcecontacts': ['Contact ID 18', 'First Name', 'Last Name', 'Mailing Street', 'Mailing City',
                            'Mailing State/Province', 'Mailing Zip/Postal Code', 'Mailing Country', 'Phone', 'Mobile',
                            'Email', 'Account ID 18', 'Volgistics ID', 'Person ID'],
-    'volgisticsshifts': ['Number', 'Place', 'Assignment', 'From date', 'To date', 'Hours'],
-    'salesforcedonations': ['Recurring donor', 'Opportunity Owner', 'Account Name', 'Opportunity ID (18 Digit)',
-                            'Account ID (18 digit)',
-                            'Opportunity Name', 'Stage', 'Fiscal Period', 'Amount', 'Probability (%)', 'Age',
-                            'Close Date', 'Created Date', 'Type', 'Primary Campaign Source',
-                            'Source', 'Contact ID (18 Digit)', 'Primary Contact'],
+    # 'volgisticsshifts': ['Number', 'Place', 'Assignment', 'From date', 'To date', 'Hours'],
+    # 'salesforcedonations': ['Recurring donor', 'Opportunity Owner', 'Account Name', 'Opportunity ID (18 Digit)',
+    #                         'Account ID (18 digit)',
+    #                         'Opportunity Name', 'Stage', 'Fiscal Period', 'Amount', 'Probability (%)', 'Age',
+    #                         'Close Date', 'Created Date', 'Type', 'Primary Campaign Source',
+    #                         'Source', 'Contact ID (18 Digit)', 'Primary Contact'],
     'manualmatches': ['salesforcecontacts', 'volgistics', 'shelterluvpeople']
 }
 
@@ -50,23 +50,23 @@ DATASOURCE_MAPPING = {
         '_table_name': ['Firstname'.lower(), 'Lastname'.lower()],
         'should_drop_first_column': False
     },
-    'volgisticsshifts': {
-        'id': 'number',
-        'csv_names': CSV_HEADERS['volgisticsshifts'],
-        'tracked_columns': list(map(__clean_csv_headers, CSV_HEADERS['volgisticsshifts'])),
-        'table_email': None,
-        '_table_name': None,
-        'sheetname': 'Service',
-        'should_drop_first_column': False
-    },
-    'salesforcedonations': {
-        'id': 'contact_id',
-        'csv_names': CSV_HEADERS['salesforcedonations'],
-        'tracked_columns': list(map(__clean_csv_headers, CSV_HEADERS['salesforcedonations'])),
-        'table_email': None,
-        '_table_name': None,
-        'should_drop_first_column': True
-    }
+    # 'volgisticsshifts': {
+    #     'id': 'number',
+    #     'csv_names': CSV_HEADERS['volgisticsshifts'],
+    #     'tracked_columns': list(map(__clean_csv_headers, CSV_HEADERS['volgisticsshifts'])),
+    #     'table_email': None,
+    #     '_table_name': None,
+    #     'sheetname': 'Service',
+    #     'should_drop_first_column': False
+    # },
+    # 'salesforcedonations': {
+    #     'id': 'contact_id',
+    #     'csv_names': CSV_HEADERS['salesforcedonations'],
+    #     'tracked_columns': list(map(__clean_csv_headers, CSV_HEADERS['salesforcedonations'])),
+    #     'table_email': None,
+    #     '_table_name': None,
+    #     'should_drop_first_column': True
+    # }
 }
 
 
@@ -115,12 +115,12 @@ SOURCE_NORMALIZATION_MAPPING = {
         }
 
     },
-    "salesforcedonations": {
-        "parent": "salesforcecontacts",
-        "others": {
-            "should_drop_first_column": True
-        }
-    },
+    # "salesforcedonations": {
+    #     "parent": "salesforcecontacts",
+    #     "others": {
+    #         "should_drop_first_column": True
+    #     }
+    # },
     "shelterluvpeople": {
         "source_id": "internal-id",
         "first_name": "firstname",
@@ -151,10 +151,10 @@ SOURCE_NORMALIZATION_MAPPING = {
             "should_drop_first_column": True
         }
     },
-    "volgisticsshifts": {
-        "parent": "volgistics",
-        "others": {
-            "should_drop_first_column": True
-        }
-    }
+    # "volgisticsshifts": {
+    #     "parent": "volgistics",
+    #     "others": {
+    #         "should_drop_first_column": True
+    #     }
+    # }
 }

--- a/src/server/pipeline/clean_and_load_data.py
+++ b/src/server/pipeline/clean_and_load_data.py
@@ -50,22 +50,7 @@ def start(connection, pdp_contacts_df, file_path_list):
                 result = pd.concat([result, source_df])
                 json_rows = pd.concat([json_rows, source_json])
 
-        else:  # it is a child table
-            if table_name in sqlalchemy.inspect(connection).get_table_names():
-                
-                # Only retain new/updated records in secondary tables (shifts, donations, etc.)
-                current_app.logger.info('   - Deduplicating old records')
-                old_data = pd.read_sql_table(table_name, connection)
-                df = old_data.append(df, ignore_index=True).drop_duplicates()
-                
-            if table_name == 'salesforcedonations':
-                df.to_sql(table_name, connection, index=False, if_exists='replace', dtype={
-                    'close_date': sqlalchemy.Date(),
-                    'created_date': sqlalchemy.Date()
-                })
-            else:
-                df.to_sql(table_name, connection, index=False, if_exists='replace')
-
+        # else:  # it is a child table, processed in file_uploader.py 
         current_app.logger.info('   - Finish load_paws_data on: ' + uploaded_file)
 
     return result, json_rows, manual_matches_df

--- a/src/server/shifts_importer.py
+++ b/src/server/shifts_importer.py
@@ -1,0 +1,42 @@
+import re
+from flask.globals import current_app
+
+from openpyxl import load_workbook
+from jellyfish import jaro_similarity
+
+from config import  engine
+
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy import  insert,  Table,  Column, MetaData, exc
+from sqlalchemy.dialects.postgresql import Insert
+metadata = MetaData()
+
+
+MINIMUM_SIMILARITY = 0.85  # How good does the table match need to be?
+
+expected_columns =  {
+            'Number' : 'volg_id',
+            'Site' : None,
+            'Place' : None,
+            'Assignment' : 'assignment',
+            'From date' : 'from_date',
+            'To date' : None,
+            'From time' :None,
+            'To time' : None,
+            'Hours' : 'hours',
+            'No Call/No Show' : None,
+            'Call/Email to miss shift' : None,
+            'Absence' : None,
+            'Volunteers' : None
+            }
+
+def validate_import_vs(filename):
+    """ Validate that the XLSX column names int the file are close enough to expectations that we can trust the data.
+        If so, insert the data into the volgisticsshifts table. 
+    """
+
+    current_app.logger.info('---------------------- Loading ' + filename.filename  + '------------------------')
+    wb = load_workbook(filename)   #  ,read_only=True should be faster but gets size incorrect 
+    ws = wb.active   # Needs to be 'Service' sheet
+    # ws.reset_dimensions()   # Tells openpyxl to ignore what sheet says and check for itself
+    ws.calculate_dimension()


### PR DESCRIPTION
This builds on PR #382 .

Following 382, it does direct import into the `volgisticsshifts` table. 
There's some clean up for changed column names:
`volgisticsshifts.number` -> `.volg_id`
`volgisticsshifts.from`  - > `.from_date`

Removes Fosters block from 360View as per KF

@sposerina  Please review `datasource_manager.py`   - Looks correct after changes?  Table mappings get used by `clean_and_load_data.py` - would it be better to feed c&l a list instead of it collecting tables from DB?  


