### PR TITLE
Support for /api/internal

### DIFF
--- a/src/client/default.conf.template
+++ b/src/client/default.conf.template
@@ -7,15 +7,24 @@ server {
     listen       80;
     server_name  localhost;
     client_max_body_size 100M;
-    
+
+    # This needs to be first location block
+    location  ^~ /api/internal {   # Blocks external access to /api/internal/*
+        return 404;
+        }
+
+
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri /index.html; # forward all requests to the index.html for react
     }
 
+  # $uri does not refer to Mr. Rotem but 'Uniform Resource Identifier'
+
     location /api {
-        try_files $uri @backend;
+        try_files $uri @backend;      
     }
 
     location @backend {

--- a/src/server/api/api.py
+++ b/src/server/api/api.py
@@ -4,6 +4,8 @@ from flask_cors import CORS
 admin_api = Blueprint("admin_api", __name__)
 common_api = Blueprint("common_api", __name__)
 user_api = Blueprint("user_api", __name__)
+internal_api = Blueprint("internal_api", __name__)
+
 
 # TODO: SECURITY - CORS is wide open for development, needs to be limited for production
 CORS(user_api)

--- a/src/server/api/internal_api.py
+++ b/src/server/api/internal_api.py
@@ -1,0 +1,20 @@
+
+from api.api import internal_api
+from flask import request, redirect, jsonify, current_app, abort, json
+from datetime import datetime
+
+
+###   Internal API endpoints can only be accessed from inside the cluster;
+###   they are blocked by location rule in NGINX config
+
+
+# Verify that this can only be accessed from within cluster
+@internal_api.route("/api/internal/test", methods=["GET"])
+def user_test():
+    """ Liveness test, does not require JWT """
+    return jsonify(("OK from INTERNAL Test  @ " + str(datetime.now())))
+
+@internal_api.route("/api/internal/test/test", methods=["GET"])
+def user_test2():
+    """ Liveness test, does not require JWT """
+    return jsonify(("OK from INTERNAL test/test  @ " + str(datetime.now())))

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -39,11 +39,12 @@ app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
 from api.admin_api import admin_api
 from api.common_api import common_api
 from api.user_api import user_api
+from api.internal_api import internal_api
 
 app.register_blueprint(admin_api)
 app.register_blueprint(common_api)
 app.register_blueprint(user_api)
-
+app.register_blueprint(internal_api)
 
 app.logger.setLevel('INFO')  # By default, Docker appears to set at INFO but VSCode at WARNING 
 


### PR DESCRIPTION
Creates /api/internal tree and blocks it from external access.


`http://localhost/api/internal/test`  returns a 404

From another container in the cluster,  `curl http://server:5000/api/internal/test` works

@urirot Can you move your    
`src/server/api/API_ingest/` code into    
`src/server/api/internal/` ?

Closes #396 