### PR TITLE
WIP: RFM import

### DIFF
--- a/src/server/api/admin_api.py
+++ b/src/server/api/admin_api.py
@@ -278,3 +278,71 @@ def  import_rfm_csv():
     rc = insert_rfm_scores(score_list)
 
     return str(rc) + " rows inserted"
+
+
+def write_rfm_edges(rfm_dict : dict) :
+    """Write the rfm edge dictionary to the DB"""
+
+    if len(rfm_dict) == 3 :  #  R, F, *and* M!
+        rfm_s = json.dumps(rfm_dict)  # Convert dict to string
+
+        metadata = MetaData()
+        kvt = Table("kv_unique", metadata, autoload=True, autoload_with=engine)
+
+        # See Alembic Revision ID: 05e0693f8cbb for table definition
+        with engine.connect() as connection:
+            ins_stmt = insert(kvt).values(               # Postgres-specific insert() supporting ON CONFLICT
+                keycol = 'rfm_edges',
+                valcol = rfm_s,
+                )
+            # If key already present in DB, do update instead
+            upsert = ins_stmt.on_conflict_do_update(
+                    constraint='kv_unique_keycol_key',
+                    set_=dict(valcol=rfm_s)
+                    )
+
+            try:
+                connection.execute(upsert)
+            except Exception as e:
+                current_app.logger.error("Insert/Update failed on rfm edge ")
+                current_app.logger.exception(e)
+                return None
+
+        return 0
+
+    else :   # Malformed dict
+        current_app.logger.error("Received rfm_edge dictionary with " + str(len(rfm_dict)) + " entries - expected 3")
+        return None
+
+
+def read_rfm_edges() :
+    """Read the rfm_edge record from the DB and return the dict."""
+
+    q = text("""SELECT valcol from kv_unique WHERE keycol = 'rfm_edges';""")
+
+    with engine.begin() as connection:   # BEGIN TRANSACTION
+        q_result = connection.execute(q)
+        if q_result.rowcount == 0:
+            current_app.logger.warning("No rfm_edge entry found in DB")
+            return None
+        else:
+            edge_string = q_result.fetchone()[0]
+            edge_dict = json.loads(edge_string)   # Convert stored string to dict
+            return edge_dict
+
+
+
+# Use this as a way to trigger functions for testing
+
+@admin_api.route("/api/admin/test_endpoint", methods=["GET"])
+def validate_rfm_edges():
+
+    d = read_rfm_edges()         # read out of DB
+    print("d is: \n" + str(d) )
+
+    write_rfm_edges(d)          # Write it back
+     
+    d = read_rfm_edges()        # read it again     
+    print("round-trip d is : \n " + str(d) )
+
+    return "OK"

--- a/src/server/api/admin_api.py
+++ b/src/server/api/admin_api.py
@@ -333,7 +333,7 @@ def read_rfm_edges() :
 
 
 # Use this as a way to trigger functions for testing
-
+# TODO: Remove when not needed
 @admin_api.route("/api/admin/test_endpoint", methods=["GET"])
 def validate_rfm_edges():
 


### PR DESCRIPTION
Quick and dirty import/insert for RFM scores - not production quality

Creates a new admin endpoint:   **/api/import_rfm**  which will import a csv file of   `matching_id, rfm_score` values
Specify the file at line 271  of admin_api.py

When you GET /api/import_rfm , the code reads in the file then passes a list of [mid,score] to the insert function. 


Once loaded, 

```
select  pdpc.matching_id, first_name, last_name, rfm_scores.rfm_score, rfm_label, rfm_color
from pdp_contacts as pdpc
left join rfm_scores on rfm_scores.matching_id = pdpc.matching_id
left join rfm_mapping on rfm_mapping.rfm_value = rfm_scores.rfm_score
LIMIT 50;
```

will show you the results.

We need to figure the best place to put this.


NB: _As matching_ids are not deterministic, this data set is only really useful with the DB from which it was generated._



Closes #399