### PR TITLE
Now populating rfm_mapping table on startup

### DIFF
--- a/src/server/alembic/populate_rfm_mapping.sql
+++ b/src/server/alembic/populate_rfm_mapping.sql
@@ -1,7 +1,7 @@
 -- Run this script in your SQL query tool
 -- Run truncate command if this table is already populated
 -- TRUNCATE TABLE rfm_mapping; 
-BEGIN;
+-- BEGIN;  
 insert into rfm_mapping values('111', 'label111','0xc0c0c0', '0x010101');
 insert into rfm_mapping values('112', 'label112','0xc0c0c0', '0x010101');
 insert into rfm_mapping values('113', 'label113','0xc0c0c0', '0x010101');
@@ -127,4 +127,4 @@ insert into rfm_mapping values('552', 'label552','0xc0c0c0', '0x010101');
 insert into rfm_mapping values('553', 'label553','0xc0c0c0', '0x010101');
 insert into rfm_mapping values('554', 'label554','0xc0c0c0', '0x010101');
 insert into rfm_mapping values('555', 'label555','0xc0c0c0', '0x010101');
-COMMIT;
+-- COMMIT;

--- a/src/server/alembic/populate_rfm_mapping.sql
+++ b/src/server/alembic/populate_rfm_mapping.sql
@@ -2,6 +2,7 @@
 -- Run truncate command if this table is already populated
 -- TRUNCATE TABLE rfm_mapping; 
 -- BEGIN;  
+--  fields are           (rfm_score, label, (background) color, text color)
 insert into rfm_mapping values('111', 'label111','0xc0c0c0', '0x010101');
 insert into rfm_mapping values('112', 'label112','0xc0c0c0', '0x010101');
 insert into rfm_mapping values('113', 'label113','0xc0c0c0', '0x010101');

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -46,6 +46,8 @@ with engine.connect() as connection:
     import user_mgmt.base_users
     user_mgmt.base_users.create_base_roles()  # IFF there are no roles already
     user_mgmt.base_users.create_base_users()  # IFF there are no users already
+    user_mgmt.base_users.populate_rfm_mapping_table(overwrite=True)   # Set to True to force loading latest version of populate script
+                                                                       # found in the server/alembic directory
 
 # Create these directories only one time - when initializing
 if not os.path.isdir(BASE_PATH):

--- a/src/server/user_mgmt/base_users.py
+++ b/src/server/user_mgmt/base_users.py
@@ -1,6 +1,9 @@
 from config import engine
 from api import user_api
 import sqlalchemy as sa
+import os
+
+
 
 try:   
     from secrets_dict import BASEUSER_PW, BASEEDITOR_PW, BASEADMIN_PW
@@ -84,3 +87,52 @@ def create_base_users():  # TODO: Just call create_user for each
 
         else:
             print(user_count, "users already present in DB, not creating")
+
+
+def populate_rfm_mapping_table(overwrite=False):
+    """Populate the rfm_mapping table if empty or overwrite is True."""
+
+    with engine.connect() as connection:
+
+        def table_empty():
+            result = connection.execute("select count(*) from rfm_mapping;")
+            row_count = result.fetchone()[0]
+            return row_count == 0
+
+
+        if overwrite or table_empty():         
+            print("Populating rfm_mapping table")
+
+            if not table_empty():
+                print("'overwrite=True', truncating rfm_mapping table")
+                connection.execute("TRUNCATE TABLE rfm_mapping;")
+
+
+            if os.path.exists('server'):    # running locally
+                file_path = os.path.normpath('server/alembic/populate_rfm_mapping.sql')
+
+            elif os.path.exists('alembic'):  # running on Docker
+                file_path = os.path.normpath('alembic/populate_rfm_mapping.sql')
+
+            else:                 # 
+                print("ERROR: Can't find a path to populate script!!!!!!")
+                print('CWD is ' + os.getcwd())
+                return
+
+
+
+            print("Loading sql script at " + file_path)
+
+            f = open(file_path)
+            populate_query = f.read()
+            f.close()
+
+            result = connection.execute(populate_query)
+
+            if table_empty():
+                print("ERROR:        rfm_mapping table WAS NOT POPULATED")
+
+        else:
+            print("rfm_mapping table already populated; overwrite not True so not changing.")
+
+    return


### PR DESCRIPTION
Added call to populate_rfm_mapping_table() in config.py with
   'overwrite=True' so it loads table at every startup.
Removed BEGIN/COMMIT from script as it runs in a transaction here.

Now you can edit **server/alembic/populate_rfm_mapping.sql** to assign labels/colors/text_colors  to RFM scores. Next server restart, the rfm_mapping table will be populated with your selections. 


Closes #417