### PR TITLE
Volunteer activity stats are now calculated from volgisticsshifts table

### DIFF
--- a/src/client/src/pages/DataView360/View/View360.js
+++ b/src/client/src/pages/DataView360/View/View360.js
@@ -49,7 +49,6 @@ class View360 extends Component {
         }
 
         this.onBackClick = this.onBackClick.bind(this);
-        this.extractVolunteerActivity = this.extractVolunteerActivity.bind(this);
     }
 
     async componentDidMount() {
@@ -107,20 +106,6 @@ class View360 extends Component {
     async getAnimalEvents(animalId, matchId) {
         let response = await fetch(`/api/person/${matchId}/animal/${animalId}/events`);
         return await response.json()
-    }
-
-    extractVolunteerActivity() {
-        const volgistics = _.find(this.state.participantData.contact_details, {"source_type": "volgistics"}) || {};
-        let volunteerActivity = {"life_hours": 0, "ytd_hours": 0, "start_date": "N/A"}
-
-        if (Object.keys(volgistics).length > 0) {
-            const volgisticsJson = JSON.parse(volgistics.json);
-            volunteerActivity = _.pick(volgisticsJson, Object.keys(volunteerActivity));
-            if (volunteerActivity["start_date"] !== "") {
-                volunteerActivity["start_date"] = moment(volunteerActivity["start_date"], "MM-DD-YYYY").format("YYYY-MM-DD");
-            }
-        }
-        return volunteerActivity;
     }
 
     onBackClick() {
@@ -182,7 +167,7 @@ class View360 extends Component {
                                                     headerText={"Foster Records"}
                                                     shelterluvShortId={_.get(this.state, 'participantData.shelterluvShortId')}
                                         /> */}
-                                        <VolunteerActivity volunteer={this.extractVolunteerActivity()} />
+                                        <VolunteerActivity volunteer={_.first(_.get(this.state, 'participantData.activity'))} />
                                         <VolunteerHistory volunteerShifts={_.get(this.state, 'participantData.shifts')} />
                                     </Grid>
                                 </Grid>

--- a/src/client/src/pages/DataView360/View/components/VolunteerActivity.js
+++ b/src/client/src/pages/DataView360/View/components/VolunteerActivity.js
@@ -9,7 +9,6 @@ import {
     TableCell,
     Container,
 } from '@material-ui/core';
-import moment from 'moment';
 import EmojiPeopleIcon from '@material-ui/icons/EmojiPeople';
 import DataTableHeader from './DataTableHeader';
 
@@ -35,14 +34,9 @@ class VolunteerActivity extends Component {
                             <TableBody>
                                 { this.props.volunteer && (
                                 <TableRow>
-                                    <TableCell>{
-                                        (this.props.volunteer.start_date === "N/A")
-                                        ? "N/A" 
-                                        : moment(this.props.volunteer.start_date).format("YYYY-MM-DD")
-                                    }
-                                    </TableCell>
-                                    <TableCell>{this.props.volunteer.life_hours.toFixed(2)}</TableCell>
-                                    <TableCell>{this.props.volunteer.ytd_hours.toFixed(2)}</TableCell>
+                                    <TableCell>{(this.props.volunteer.start_date) ? this.props.volunteer.start_date : "N/A"}</TableCell>
+                                    <TableCell>{(this.props.volunteer.life_hours) ? this.props.volunteer.life_hours.toFixed(2) : 0}</TableCell>
+                                    <TableCell>{(this.props.volunteer.ytd_hours) ? this.props.volunteer.ytd_hours.toFixed(2) : 0}</TableCell>
                                 </TableRow>
                                 )}
                             </TableBody>


### PR DESCRIPTION
This PR calculates the stats for the VolunteerActivity section from the data in the `volgisticsshifts` table as part of the `/api/360/<matching_id>` endpoint.