### PR TITLE
Fixed bug where RFM list was empty upon return from 360 View

### DIFF
--- a/src/client/src/pages/RFM/RFM.js
+++ b/src/client/src/pages/RFM/RFM.js
@@ -64,8 +64,7 @@ export function RFM(props) {
                 let state = JSON.parse(_.get(history, 'location.state'));
                 let stateLabel = state.selectedLabel;
                 if (stateLabel) {
-                    await setSelectedLabel(stateLabel)
-                    await handleLabelChange({target: {value: stateLabel}});
+                    await handleLabelChange(stateLabel);
                 }
             } catch {
             }
@@ -136,8 +135,8 @@ export function RFM(props) {
                                 </Grid>
                                 <Grid container item direction="column" spacing={2}>
                                     {
-                                        _.map(labels, labelData => {
-                                            return <Grid item>
+                                        labels.map((labelData, index) => {
+                                            return <Grid item key={index}>
                                                 <Button onClick={() => handleLabelChange(labelData)}
                                                         style={{
                                                             backgroundColor: labelData.rfm_color,


### PR DESCRIPTION
Fixes #432.  Now, if you pull up the RFM list, click on a name, then click 'Back to Results', you'll return to the RFM list and the names will be there.