### PR TITLE
doc: Update readme to reflect correct port

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -19,7 +19,7 @@ _Docker Compose instructions_
 - `docker-compose up -d` to bring up the application.
 - Scheduler docker will not start. To run the scheduler, use profile flag `production-only` as explained in the Production Environment section.
 
-#### Finally - Run The UI on http://localhost:3000
+#### Finally - Run The UI on http://localhost:80
 
 ---------------------------------------
 Production Environment


### PR DESCRIPTION
Mine works at 80 and the compose file seems to match 80:80. I think just the readme is maybe out of date.