### PR TITLE
Adds deployment strategy: Recreate

### DIFF
--- a/src/helm-chart/templates/deployment.yaml
+++ b/src/helm-chart/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "helm-chart.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
This is instead of the default Rollling deployment,
which fails because the PVs are RWO, so we have to
kill old server container before starting new.