### PR TITLE
Support role names in /api/admin/user/update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ start_env.sh
 .mypy_cache/
 *secrets*
 *kustomization*
+src/.venv/


### PR DESCRIPTION
Accepts text-based role names for /api/admin/user/update


Closes #525 