### PR TITLE
510- Salesforce updated contact info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ src/server/api/__pycache__
 /.idea
 start_env.sh
 *.DS_Store
-
 /src/server/venv/
 /src/local_files/
 /src/server/secrets_dict.py

--- a/src/server/api/API_ingest/updated_data.py
+++ b/src/server/api/API_ingest/updated_data.py
@@ -46,8 +46,8 @@ def get_updated_contact_data():
             (to_timestamp(foster_return ) at time zone 'America/New_York')::date  as "updatedFosterEndDate",
 
             min(vs.from_date) as "updatedFirstVolunteerDate",
-            max(vs.from_date) as "updatedLastVolunteerDate"
-        -- ,    slc.source_id as sl_id, slc.matching_id,  vc.source_id as vc_id
+            max(vs.from_date) as "updatedLastVolunteerDate",
+            vc.source_id as   "volgisticsId"     
 
             
         from 
@@ -64,6 +64,7 @@ def get_updated_contact_data():
         group by
             slsf.source_id,
             slp.id,
+            vc.source_id,
             foster_out ,
             foster_return
         

--- a/src/server/api/API_ingest/updated_data.py
+++ b/src/server/api/API_ingest/updated_data.py
@@ -40,7 +40,7 @@ def get_updated_contact_data():
                     or (extract(epoch from now())::bigint - foster_return < 365*86400) -- foster return 
                 then 'Active'
                 else 'Inactive'
-            end  as "updatedVolunteerStatus" ,
+            end  as "updatedFosterStatus" ,
         
             (to_timestamp(foster_out ) at time zone  'America/New_York')::date   as "updatedFosterStartDate",
             (to_timestamp(foster_return ) at time zone 'America/New_York')::date  as "updatedFosterEndDate",

--- a/src/server/api/API_ingest/updated_data.py
+++ b/src/server/api/API_ingest/updated_data.py
@@ -1,0 +1,79 @@
+
+from sqlalchemy.orm import  sessionmaker
+from simple_salesforce import Salesforce
+from config import engine
+
+import structlog
+logger = structlog.get_logger()
+
+
+def get_updated_contact_data():
+    Session = sessionmaker(engine)
+
+    qry = """ -- Collect latest foster/volunteer dates
+        with ev_dates as 
+        (select 
+            person_id, 
+            max(case when event_type=1 then time else null end) adopt,
+            max(case when event_type=2 then time else null end) foster_out,
+           --  max(case when event_type=3 then time else null end) rto,
+            max(case when event_type=5 then time else null end) foster_return
+           
+        from 
+            sl_animal_events sla
+            left join sl_event_types sle on sle.id = sla.event_type
+            
+        where sle.id in (1,2,5)
+        group by person_id
+        order by person_id
+        )
+  
+
+    select json_agg (upd)  as "cd" from (
+            select
+            slsf.source_id as "contactId" ,  -- long salesforce string
+            slp.id   as  "personId" ,           -- short PAWS-local shelterluv id
+        
+            case
+                when 
+                    (extract(epoch from now())::bigint - foster_out < 365*86400)  -- foster out in last year 
+                    or (extract(epoch from now())::bigint - foster_return < 365*86400) -- foster return 
+                then 'Active'
+                else 'Inactive'
+            end  as "updatedVolunteerStatus" ,
+        
+            (to_timestamp(foster_out ) at time zone  'America/New_York')::date   as "updatedFosterStartDate",
+            (to_timestamp(foster_return ) at time zone 'America/New_York')::date  as "updatedFosterEndDate",
+
+            min(vs.from_date) as "updatedFirstVolunteerDate",
+            max(vs.from_date) as "updatedLastVolunteerDate"
+        -- ,    slc.source_id as sl_id, slc.matching_id,  vc.source_id as vc_id
+
+            
+        from 
+            ev_dates
+            left join pdp_contacts slc on slc.source_id = person_id::text and slc.source_type = 'shelterluvpeople'
+            left join pdp_contacts slsf on slsf.matching_id = slc.matching_id and slsf.source_type = 'salesforcecontacts'
+            left join shelterluvpeople slp on slp.internal_id = person_id::text
+            left join pdp_contacts vc on vc.matching_id = slc.matching_id and vc.source_type = 'volgistics'
+            left join volgisticsshifts vs on vs.volg_id::text = vc.source_id 
+
+    where 
+        slsf.source_id is not null
+
+        group by
+            slsf.source_id,
+            slp.id,
+            foster_out ,
+            foster_return
+        
+    ) upd ;
+
+
+    """
+
+    with Session() as session:
+        result = session.execute(qry)
+        sfdata = result.fetchone()[0]
+        logger.debug("Query for Salesforce update returned %d records", len(sfdata))
+        return sfdata

--- a/src/server/api/internal_api.py
+++ b/src/server/api/internal_api.py
@@ -3,9 +3,10 @@ from datetime import datetime
 import structlog
 from flask import jsonify
 
-from api.API_ingest import ingest_sources_from_api
+from api.API_ingest import ingest_sources_from_api, salesforce_contacts
 from api.api import internal_api
 from rfm_funcs.create_scores import create_scores
+from server.api.API_ingest import updated_data
 
 logger = structlog.get_logger()
 
@@ -42,3 +43,11 @@ def hit_create_scores():
     tuple_count = create_scores()
     logger.info("create_scores()  processed %s scores",  str(tuple_count) )
     return jsonify(200)
+
+
+@internal_api.route("/api/internal/get_updated_data", methods=["GET"])
+def get_contact_data():
+    logger.debug("Calling  get_updated_contact_data()")
+    contact_json =  updated_data.get_updated_contact_data()
+    logger.debug("Returning %d contact records",  len(contact_json) )
+    return jsonify(contact_json), 200


### PR DESCRIPTION
Adds new internal endpoint `/api/internal/get_updated_data`  
( api/API_ingest/updated_data.py/get_updated_contact_data() ) 
which returns a JSON array of contact info like

```
[
  {
	  contactId: ‘0032g00000Ukx9bAAB’,
	  personId: ‘1234’,
	  volgisticsId: 1234,
	  updatedVolunteerStatus: ‘Active’,
	  updatedFirstVolunteerDate: 2021/01/01,
	  updatedLastVolunteerDate: 2021/02/02,
	  updatedFosterStartDate: 2020/10/18,
	  updatedFosterEndDate: 2022/01/01
  },
]
```

Enables #506 

Closes #510 