### PR TITLE
562: Remove invalid import

### DIFF
--- a/src/server/api/internal_api.py
+++ b/src/server/api/internal_api.py
@@ -9,7 +9,7 @@ from api.api import internal_api
 
 from pipeline import flow_script
 from pub_sub import salesforce_message_publisher
-from rfm_funcs.create_scores import create_scores
+# from rfm_funcs.create_scores import create_scores
 
 
 logger = structlog.get_logger()


### PR DESCRIPTION
- https://github.com/CodeForPhilly/paws-data-pipeline/pull/554 removed `rfm_funcs` folder and commented out the import and use of `rfm_funcs.create_scores` and https://github.com/CodeForPhilly/paws-data-pipeline/pull/560 uncommented .
- This PR comments the import out again.