### PR TITLE
588: Delete invalid data from pdp_contacts

### DIFF
--- a/src/server/pipeline/flow_script.py
+++ b/src/server/pipeline/flow_script.py
@@ -70,6 +70,9 @@ def start_flow():
             logger.debug("Clearing pdp_contacts to prepare for match")
             reset_pdp_contacts_with_unmatched(conn)
 
+            logger.debug("Removing invalid entries from pdp_contacts")
+            filter_invalid_pdp_data(conn)
+
             logger.debug("Computing automatic matches")
             automatic_matches = get_automatic_matches(conn)
             logger.debug("Computing manual matches")
@@ -127,6 +130,62 @@ def name_to_array(n):
 
 def compare_names(n1, n2):
     return name_to_array(n1).bool_op("&&")(name_to_array(n2))
+
+
+def filter_invalid_pdp_data(conn):
+    pc = PdpContacts.__table__.alias()
+    lower_first_name = func.lower(pc.c.first_name)
+    lower_last_name = func.lower(pc.c.last_name)
+
+    unknown = and_(
+        lower_first_name.ilike("%unknown%"),
+        lower_last_name.ilike("%unknown%")
+    )
+
+    # It would be preferable to use sqlalchemy statements, but that proved difficult
+    digits_only = and_(
+        text("""LOWER(first_name) ~ '^\d+$'"""),
+        text("""LOWER(last_name) ~ '^\d+$'""")
+    )
+
+    question_mark = and_(
+        lower_first_name == '?',
+        lower_last_name == '?'
+    )
+
+    john_doe = and_(
+        lower_first_name == "john",
+        lower_last_name == "doe"
+    )
+
+    no_name_no_name = and_(
+        lower_first_name == "no name",
+        lower_last_name == "no name"
+    )
+
+    no_name = and_(
+        lower_first_name == "no",
+        lower_last_name == "name"
+    )
+
+    none_friends = and_(
+        lower_first_name.is_(None),
+        lower_last_name == "friends"
+    )
+
+    composite_condition = or_(
+        unknown,
+        digits_only,
+        question_mark,
+        john_doe,
+        no_name_no_name,
+        no_name,
+        none_friends,
+    )
+
+    delete_stmt = delete(pc).where(composite_condition)
+
+    return conn.execute(delete_stmt)
 
 
 def get_automatic_matches(conn):


### PR DESCRIPTION
Closes https://github.com/CodeForPhilly/paws-data-pipeline/issues/588

## Changes
- Deletes invalid data from `pdp_contacts` before matching process begins

#### Considerations
- It felt cleanest to just delete the data from `pdp_contacts` as a separate step before we start the matching process. I think the ideal would be to never insert these values into `pdp_contacts` to begin with, but I don't think this is very expensive.