### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/src/server/api/API_ingest/shelterluv_animals.py
+++ b/src/server/api/API_ingest/shelterluv_animals.py
@@ -42,7 +42,7 @@ def get_animal_count():
     URL = path.join(BASE_URL,animals)
 
     try:
-        response = requests.request("GET",URL, headers=headers)
+        response = requests.request("GET",URL, headers=headers, timeout=60)
     except Exception as e:
         logger('get_animal_count failed with ', e)
         return -2
@@ -69,7 +69,7 @@ def get_updated_animal_count(last_update):
     URL = path.join(BASE_URL,animals)
 
     try:
-        response = requests.request("GET",URL, headers=headers)
+        response = requests.request("GET",URL, headers=headers, timeout=60)
     except Exception as e:
         logger('get_updated_animal_count failed with ', e)
         return -2
@@ -136,7 +136,7 @@ def get_animals_bulk(total_count):
         url = raw_url.format(offset,limit)
 
         try:
-            response = requests.request("GET",url, headers=headers)
+            response = requests.request("GET",url, headers=headers, timeout=60)
         except Exception as e:
             logger('get_animals failed with ', e)
             return -2

--- a/src/server/api/API_ingest/shelterluv_people.py
+++ b/src/server/api/API_ingest/shelterluv_people.py
@@ -51,7 +51,7 @@ def store_shelterluv_people_all():
 
         while has_more:
             r = requests.get("http://shelterluv.com/api/v1/people?limit={}&offset={}".format(LIMIT, offset),
-                             headers={"x-api-key": SHELTERLUV_SECRET_TOKEN})
+                             headers={"x-api-key": SHELTERLUV_SECRET_TOKEN}, timeout=60)
             response = r.json()
             for person in response["people"]:
                 #todo: Does this need more "null checks"?

--- a/src/server/api/API_ingest/sl_animal_events.py
+++ b/src/server/api/API_ingest/sl_animal_events.py
@@ -79,7 +79,7 @@ def get_event_count():
     URL = path.join(BASE_URL, events)
 
     try:
-        response = requests.request("GET", URL, headers=headers)
+        response = requests.request("GET", URL, headers=headers, timeout=60)
     except Exception as e:
         logger.error("get_event_count failed with ", e)
         return -2
@@ -121,7 +121,7 @@ def get_events_bulk():
         url = raw_url.format(offset, limit)
 
         try:
-            response = requests.request("GET", url, headers=headers)
+            response = requests.request("GET", url, headers=headers, timeout=60)
         except Exception as e:
             logger.error("get_events failed with ", e)
             return -2

--- a/src/server/api/common_api.py
+++ b/src/server/api/common_api.py
@@ -197,13 +197,13 @@ def get_animals(matching_id):
             for row in rows:               
                 shelterluv_id = row["source_id"]
                 person_url = f"http://shelterluv.com/api/v1/people/{shelterluv_id}"
-                person_details = requests.get(person_url, headers={"x-api-key": SHELTERLUV_SECRET_TOKEN}).json()
+                person_details = requests.get(person_url, headers={"x-api-key": SHELTERLUV_SECRET_TOKEN}, timeout=60).json()
                 if "ID" in person_details:
                     result["person_details"]["shelterluv_short_id"] = person_details["ID"]
                     animal_ids = person_details["Animal_ids"]
                     for animal_id in animal_ids:
                         animal_url = f"http://shelterluv.com/api/v1/animals/{animal_id}"
-                        animal_details = requests.get(animal_url, headers={"x-api-key": SHELTERLUV_SECRET_TOKEN}).json()
+                        animal_details = requests.get(animal_url, headers={"x-api-key": SHELTERLUV_SECRET_TOKEN}, timeout=60).json()
                         result["animal_details"][animal_id] = animal_details
 
     return result
@@ -226,7 +226,7 @@ def get_person_animal_events(matching_id, animal_id):
             row = rows[0]
             shelterluv_id = row["source_id"]
             animal_url = f"http://shelterluv.com/api/v1/animals/{animal_id}/events"
-            event_details = requests.get(animal_url, headers={"x-api-key": SHELTERLUV_SECRET_TOKEN}).json()
+            event_details = requests.get(animal_url, headers={"x-api-key": SHELTERLUV_SECRET_TOKEN}, timeout=60).json()
             for event in event_details["events"]:
                 for record in event["AssociatedRecords"]:
                     if record["Type"] == "Person" and record["Id"] == shelterluv_id:

--- a/src/server/pub_sub/salesforce_message_publisher.py
+++ b/src/server/pub_sub/salesforce_message_publisher.py
@@ -44,7 +44,7 @@ def send_pipeline_update_messages(contacts_list):
     r = requests.post('https://{}.salesforce.com/services/oauth2/token'.format(DOMAIN), data={
         'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
         'assertion': assertion,
-    })
+    }, timeout=60)
     access_token = r.json()['access_token']
     logger.info('Made OAuth call to get access token')
 

--- a/src/server/test_api.py
+++ b/src/server/test_api.py
@@ -86,7 +86,7 @@ def test_client_dns():
 # Simple API tests  ################################################
 def test_usertest():
     """Verify liveness test works"""
-    response = requests.get(SERVER_URL + "/api/user/test")
+    response = requests.get(SERVER_URL + "/api/user/test", timeout=60)
     assert response.status_code == 200
 
 ########   Dependent tests   #################################
@@ -107,7 +107,7 @@ def test_userlogin(state: State):
     """Verify base_user can log in/get JWT."""
     data = {"username":"base_user", "password" : BASEUSER_PW}
 
-    response = requests.post(SERVER_URL + "/api/user/login", json=data)
+    response = requests.post(SERVER_URL + "/api/user/login", json=data, timeout=60)
     assert response.status_code == 200
 
     try:
@@ -129,7 +129,7 @@ def test_useraccess(state: State):
     assert len(b_string) > 24
 
     auth_hdr = {'Authorization' : b_string}
-    response = requests.get(SERVER_URL + "/api/user/test_auth", headers=auth_hdr)
+    response = requests.get(SERVER_URL + "/api/user/test_auth", headers=auth_hdr, timeout=60)
     assert response.status_code == 200
 
 
@@ -137,7 +137,7 @@ def test_user_bad_pw():
     """Verify base_user with bad pw fails"""
     data = {"username":"base_user", "password" : 'some_bad_password'}
 
-    response = requests.post(SERVER_URL + "/api/user/login", json=data)
+    response = requests.post(SERVER_URL + "/api/user/login", json=data, timeout=60)
     assert response.status_code == 401
 
 
@@ -145,7 +145,7 @@ def test_inact_userblocked(state: State):
     """Verify base_user_inact can't login because marked inactive."""
     # Same pw as base_user
     data = {"username":"base_user_inact", "password" : BASEUSER_PW}
-    response = requests.post(SERVER_URL + "/api/user/login", json=data)
+    response = requests.post(SERVER_URL + "/api/user/login", json=data, timeout=60)
     assert response.status_code == 401
 
 ###   Admin-level tests ######################################
@@ -154,7 +154,7 @@ def test_adminlogin(state: State):
     """Verify base_admin can log in/get JWT."""
     data = {"username":"base_admin", "password" : BASEADMIN_PW}
 
-    response = requests.post(SERVER_URL + "/api/user/login", json=data)
+    response = requests.post(SERVER_URL + "/api/user/login", json=data, timeout=60)
     assert response.status_code == 200
 
     try:
@@ -176,7 +176,7 @@ def test_admingetusers(state: State):
     assert len(b_string) > 24
 
     auth_hdr = {'Authorization' : b_string}
-    response = requests.get(SERVER_URL + "/api/admin/user/get_users", headers=auth_hdr)
+    response = requests.get(SERVER_URL + "/api/admin/user/get_users", headers=auth_hdr, timeout=60)
     assert response.status_code == 200
 
     userlist = response.json()
@@ -192,7 +192,7 @@ def test_check_usernames(state: State):
     auth_hdr = {'Authorization' : b_string}
 
     data = {"username":"base_admin"}
-    response = requests.post(SERVER_URL + "/api/admin/user/check_name", headers=auth_hdr, json=data)
+    response = requests.post(SERVER_URL + "/api/admin/user/check_name", headers=auth_hdr, json=data, timeout=60)
     assert response.status_code == 200
 
     is_user = response.json()
@@ -206,7 +206,7 @@ def test_check_badusernames(state: State):
     auth_hdr = {'Authorization' : b_string}
 
     data = {"username":"got_no_username_like_this"}
-    response = requests.post(SERVER_URL + "/api/admin/user/check_name", headers=auth_hdr, json=data)
+    response = requests.post(SERVER_URL + "/api/admin/user/check_name", headers=auth_hdr, json=data, timeout=60)
     assert response.status_code == 200
 
     is_user = response.json()
@@ -220,7 +220,7 @@ def test_admin_currentFiles(state: State):
     assert len(b_string) > 24
     auth_hdr = {'Authorization' : b_string}
 
-    response = requests.get(SERVER_URL + "/api/listCurrentFiles",  headers=auth_hdr)
+    response = requests.get(SERVER_URL + "/api/listCurrentFiles",  headers=auth_hdr, timeout=60)
     assert response.status_code == 200
 
 
@@ -231,7 +231,7 @@ def test_admin_statistics(state: State):
     assert len(b_string) > 24
     auth_hdr = {'Authorization' : b_string}
 
-    response = requests.get(SERVER_URL + "/api/statistics", headers=auth_hdr)
+    response = requests.get(SERVER_URL + "/api/statistics", headers=auth_hdr, timeout=60)
     assert response.status_code == 200
 
 
@@ -243,7 +243,7 @@ def test_usergetusers(state: State):
     assert len(b_string) > 24
 
     auth_hdr = {'Authorization' : b_string}
-    response = requests.get(SERVER_URL + "/api/admin/user/get_users", headers=auth_hdr)
+    response = requests.get(SERVER_URL + "/api/admin/user/get_users", headers=auth_hdr, timeout=60)
     assert response.status_code == 403
 
 
@@ -254,7 +254,7 @@ def test_currentFiles(state: State):
     assert len(b_string) > 24
     auth_hdr = {'Authorization' : b_string}
 
-    response = requests.get(SERVER_URL + "/api/listCurrentFiles", headers=auth_hdr)
+    response = requests.get(SERVER_URL + "/api/listCurrentFiles", headers=auth_hdr, timeout=60)
     assert response.status_code == 200
 
 
@@ -265,7 +265,7 @@ def test_statistics(state: State):
     assert len(b_string) > 24
     auth_hdr = {'Authorization' : b_string}
     
-    response = requests.get(SERVER_URL + "/api/statistics", headers=auth_hdr)
+    response = requests.get(SERVER_URL + "/api/statistics", headers=auth_hdr, timeout=60)
     assert response.status_code == 200
 
 
@@ -286,7 +286,7 @@ def test_user_get_person_animal_events(state: State):
     url = SERVER_URL + "/api/person/12345/animal/12345/events"
 
     try:
-        response = requests.get(url, headers = auth_hdr)
+        response = requests.get(url, headers = auth_hdr, timeout=60)
     except Exception as err:
         logger.error(err)
     else:
@@ -310,7 +310,7 @@ def test_user_get_animals(state: State):
     url = SERVER_URL + "/api/person/12345/animals"
 
     try:
-        response = requests.get(url, headers = auth_hdr)
+        response = requests.get(url, headers = auth_hdr, timeout=60)
     except Exception as err:
         logger.error(err)
     else:
@@ -339,7 +339,7 @@ def test_user_get_animals_sl_token(state: State):
     url = SERVER_URL + "/api/person/12345/animals"
 
     try:
-        response = requests.get(url, headers = auth_hdr)
+        response = requests.get(url, headers = auth_hdr, timeout=60)
     except Exception as err:
         logger.error(err)
         pytest.fail('test_user_get_animals_sl_token - Request failed', pytrace=False)
@@ -365,7 +365,7 @@ def test_user_get_person_animal_events_sl_token(state: State):
     url = SERVER_URL + "/api/person/12345/animal/12345/events"
 
     try:
-        response = requests.get(url, headers = auth_hdr)
+        response = requests.get(url, headers = auth_hdr, timeout=60)
     except Exception as err:
         logger.error(err)
         pytest.fail('test_user_get_person_animal_events_sl_token - Request failed', pytrace=False)


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>


Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fpaws-data-pipeline%7C0e01c13d8c1aa8bcab9cc31d1b7a98417ce81b86)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->
