### PR TITLE
sanitize numbers

### DIFF
--- a/src/server/utils.py
+++ b/src/server/utils.py
@@ -1,0 +1,28 @@
+import re
+
+def standardize_phone_number(phone):
+    """Standardize phone number format.
+    
+    Args:
+        phone (str): The phone number to standardize.
+    
+    Returns:
+        str: The standardized phone number.
+    """
+    # Remove all non-numeric characters
+    phone = re.sub(r'\D', '', phone)
+
+    # if the phone number is less than 10 digits, it's invalid
+    if len(phone) < 10:
+        return None
+
+    # If the phone number is exactly 10 digits, return as is
+    if len(phone) == 10:
+        return phone
+
+    # if the phone number is greater than 10 digits, take the last 10 digits
+    if len(phone) > 10:
+        return f'{phone[-10:]}'
+
+    # anything else we ignore
+    return None

--- a/src/server/volgistics_importer.py
+++ b/src/server/volgistics_importer.py
@@ -1,10 +1,10 @@
-import re
 from flask.globals import current_app
 from datetime import datetime, timedelta 
 from openpyxl import load_workbook
 from jellyfish import jaro_similarity
 
 from config import  engine
+from utils import standardize_phone_number
 
 import structlog
 
@@ -178,6 +178,10 @@ def volgistics_people_import(workbook):
     col_email = col['Email']
     time_stamp = datetime.utcnow()
 
+    home_phone = standardize_phone_number(r[col_home])
+    work_phone = standardize_phone_number(r[col_work])
+    cell_phone = standardize_phone_number(r[col_cell])
+
     try:
         for r in ws.iter_rows(min_row=2, max_col=42,values_only=True):
             insert_list.append(
@@ -194,9 +198,9 @@ def volgistics_people_import(workbook):
                     "state": r[col_state],
                     "zip": r[col_zip],
                     "all_phone_numbers": r[col_all_phones],
-                    "home": r[col_home],
-                    "work": r[col_work],
-                    "cell": r[col_cell],
+                    "home": home_phone,
+                    "work": work_phone,
+                    "cell": cell_phone,
                     "email": r[col_email],
                     "created_date" : time_stamp
                 }


### PR DESCRIPTION
Handles the following cases:

```python
# Standard US numbers
("223-456-7890", "+12234567890"),
("(223) 456-7890", "+12234567890"),
("223 456 7890", "+12234567890"),
("2234567890", "+12234567890"),
# US numbers with country code
("+1 (223) 456-7890", "+12234567890"),
("1-223-456-7890", "+12234567890"),
("1-223-456-7890", "+12234567890"),
("+12234567890", "+12234567890"),
# Invalid cases
("12345", None),  # Too short
("abcdefg", None),  # Non-numeric
("", None),  # Empty input
```

Any phone numbers > 10 digits we just take the last 10 digits of the number to use